### PR TITLE
add:問題詳細表示機能実装 ※箱のみ

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -17,6 +17,10 @@ class QuestionsController < ApplicationController
     end
   end
 
+  def show
+    @question = Question.find(params[:id])
+  end
+
   private
 
   def question_params

--- a/app/views/questions/_question.html.erb
+++ b/app/views/questions/_question.html.erb
@@ -1,8 +1,9 @@
+
 <div id="question-id-<%= question.id %>">
-  <div class="card w-full bg-base-100 card-s shadow-sm">
+  <div class="card w-full bg-base-100 card-s shadow-md">
       <div class="card-body items-center text-center">
         <h4 class="card-title">
-          <%= link_to question.title, '#', class: "link link-primary text-2xl" %>
+          <%= link_to question.title, question_path(question), class: "hover:underline" %>
         </h4>
         <div class="flex justify-end gap-2 mb-2">
           <%= link_to '#', id: "button-edit-#{question.id}", class: "btn btn-ghost btn-sm" do %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,0 +1,42 @@
+<div class="container mx-auto pt-5 px-4">
+  <div class="mb-3 grid grid-cols-1 lg:grid-cols-8">
+    <div class="lg:col-start-2 lg:col-span-6">
+      <h1 class="text-3xl font-bold mb-4"><%= t('.title') %></h1>
+      <article class="card bg-base-100 shadow-md">
+        <div class="card-body">
+          <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div>
+            </div>
+            <div class="md:col-span-3">
+              <h3 class="text-xl font-semibold inline"><%= @question.title %></h3>
+              <ul class="flex flex-wrap text-sm text-gray-500 mt-1 mb-2">
+                <li class="mr-4"><%= "by #{@question.user.name}" %></li>
+                <li><%= l @question.created_at, format: :long %></li>
+              </ul>
+              <div class="flex justify-end space-x-2">
+                <%= link_to "#", id: "button-edit-#{@question.id}", class: "btn btn-sm btn-outline" do %>
+                  <i class="fas fa-pencil-alt"></i>
+                <% end %>
+                <%= link_to "#", id: "button-delete-#{@question.id}", class: "btn btn-sm btn-outline" do %>
+                  <i class="fas fa-trash"></i>
+                <% end %>
+              </div>
+            </div>
+          </div>
+          <p class="mt-4 whitespace-pre-line"><%= simple_format(@question.description) %></p>
+        </div>
+      </article>
+    </div>
+  </div>
+
+  <%# コメントフォーム %>
+  <div class="grid grid-cols-1 lg:grid-cols-8">
+    <div class="lg:col-start-2 lg:col-span-6">
+      <table class="table w-full">
+        <tbody id="table-comment">
+          <%# コメント一覧 %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,3 +7,5 @@ ja:
   questions:
     new:
       title: 問題作成
+    show:
+      title: 問題詳細

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # resources :static_pages
   root "static_pages#top"
 
-  resources :questions, only: %i[index new create]
+  resources :questions, only: %i[index new create show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
# 概要
- 問題詳細表示機能を実装しました。
※最終的な問題詳細表示機能では、今回作成した問題詳細画面の中に更に他のモデル（CardSetモデル）の項目を追加して操作します。
そのため、今回の問題詳細表示機能追加は **箱のみ** となります。