### PR TITLE
update:結果シェア時のハッシュタグ・URL変更＆問題作成後のXシェア機能を追加

### DIFF
--- a/app/views/games/result.html.erb
+++ b/app/views/games/result.html.erb
@@ -88,7 +88,7 @@
         <h3 class="card-title justify-center text-2xl">
         <div class="flex flex-wrap justify-center gap-4">
           <!-- Twitter/X シェア -->
-          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」に挑戦！\n正答率: #{@accuracy}% (#{@correct_clicks}/#{@total_clicks}クリック)\n完了問題: #{@total_matches}/#{@required_matches}問\n時間: #{sprintf('%02d:%02d', (@game_duration / 60).to_i, (@game_duration % 60).to_i)}\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape(request.base_url)}", 
+          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」に挑戦！\n正答率: #{@accuracy}% (#{@correct_clicks}/#{@total_clicks}クリック)\n完了問題: #{@total_matches}/#{@required_matches}問\n時間: #{sprintf('%02d:%02d', (@game_duration / 60).to_i, (@game_duration % 60).to_i)}\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape("#{request.base_url}/games/#{@question.id}")}", 
                   target: "_blank",
                   class: "btn btn-neutral text-2xl shadow-xl mb-8" do %>
             <div>

--- a/app/views/games/result.html.erb
+++ b/app/views/games/result.html.erb
@@ -88,7 +88,7 @@
         <h3 class="card-title justify-center text-2xl">
         <div class="flex flex-wrap justify-center gap-4">
           <!-- Twitter/X シェア -->
-          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」に挑戦！\n正答率: #{@accuracy}% (#{@correct_clicks}/#{@total_clicks}クリック)\n完了問題: #{@total_matches}/#{@required_matches}問\n時間: #{sprintf('%02d:%02d', (@game_duration / 60).to_i, (@game_duration % 60).to_i)}\n\n#NeuroWord #単語ゲーム")}&url=#{CGI.escape(request.base_url)}", 
+          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」に挑戦！\n正答率: #{@accuracy}% (#{@correct_clicks}/#{@total_clicks}クリック)\n完了問題: #{@total_matches}/#{@required_matches}問\n時間: #{sprintf('%02d:%02d', (@game_duration / 60).to_i, (@game_duration % 60).to_i)}\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape(request.base_url)}", 
                   target: "_blank",
                   class: "btn btn-neutral text-2xl shadow-xl mb-8" do %>
             <div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -23,6 +23,23 @@
         </div>
       </div>
 
+      <!-- シェアセクション -->
+      <% if current_user && current_user.own?(@question) %>
+        <p class="text-center">このボタンは、問題作成者のみに表示されます</p>
+        <h3 class="card-title justify-center text-2xl">
+        <div class="flex flex-wrap justify-center gap-4">
+          <!-- Twitter/X シェア -->
+          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」を作ったよ！\n挑戦してみてね🙌\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape("#{request.base_url}/games/#{@question.id}")}", 
+                  target: "_blank",
+                  class: "btn btn-neutral text-2xl shadow-xl mb-8" do %>
+            <div>
+            <i class="fab fa-x-twitter mr-2"></i>
+            でこの問題をシェア！
+            </div>
+          <% end %>
+        </div>
+        </h3>
+      <% end %>
 
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <!-- メインコンテンツ -->


### PR DESCRIPTION
# 概要
- 結果シェア時のハッシュタグを「#NeuroWord」から「#仲間言葉探し」に変更しました。  
  (既に「#NeuroWord」タグを使用しているXユーザーが見受けられたため)
- 結果シェア時のURLを、対象の問題それぞれのURLとなるように変更しました。
- 問題作成後に表示される、問題詳細画面からのXシェア機能を追加しました（問題作成者分のみ）。