### PR TITLE
fix:名前を空文字で登録できないよう、バリデーションを追加＆新規登録・ログイン画面から余分な表記を削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  validates :name, presence: true, length: { maximum: 20 }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,13 +9,11 @@
   <fieldset class="fieldset">
     <%= f.label :name, class: "fieldset-legend" %>
     <%= f.text_field :name, class: "input", placeholder: "ユーザー名を入力", autofocus: true %>
-    <p class="label">Optional</p>
   </fieldset>
 
   <fieldset class="fieldset">
     <%= f.label :email, class: "fieldset-legend" %>
     <%= f.email_field :email, class: "input", autocomplete: "email", placeholder: "例：sample@example.com"  %>
-    <p class="label">Optional</p>
   </fieldset>
 
   <fieldset class="fieldset">
@@ -36,6 +34,6 @@
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<p><%= link_to "ログインはこちら", new_user_session_path, class: "link mt-12" %></p>
 </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -29,8 +29,8 @@
         <%= f.submit t('devise.sessions.new.sign_in'), class: "btn btn-primary" %>
       </div>
     <% end %>
-
-  <%= render "devise/shared/links" %>
+    <p><%= link_to "アカウント登録はこちら", new_user_registration_path, class: "link mt-12" %></p>
   </div>
 </div>
+
 


### PR DESCRIPTION
# 概要
- ユーザー名が空文字で登録できる状態だったため、文字数上限も含むバリデーションを追加しました。
- 新規登録・ログイン画面から余分な表記（optionalなど）を削除しました。