### PR TITLE
fix:未ログインユーザーは、index・show以外のquestionsページへのアクセスが不可となるよう修正

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,4 +1,6 @@
 class QuestionsController < ApplicationController
+  before_action :authenticate_user!, except: [ :index, :show ]
+
   def index
     @questions = Question.includes(:user).order(created_at: :desc)
   end


### PR DESCRIPTION
# 概要
- ログイン前でも https://neuroword.onrender.com/questions/new にアクセス可能な状態となっていたため、questions_controllerにbefore_actionを追加しました。
  - 追加したbefore_actionの内容：index/show以外は、ログイン状態かどうかをチェックする