### PR TITLE
fix&add:default_meta_tagにtwitter設定追記・デフォルトOGP画像追加・他

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -54,7 +54,7 @@ class GamesController < ApplicationController
 
     # OGP
     pattern = /[\p{Emoji}\p{Emoji_Component}&&[:^ascii:]]/
-    @url = "https://res.cloudinary.com/dyafcag5y/image/upload/l_text:TakaoPGothic_60_bold:～#{@question.title.gsub(pattern, '')}～%0Aに挑戦したよ！,co_rgb:421,w_900,c_fit/v1752043572/ixs5grlxhrds2aprflcn.png"
+    @url = "https://res.cloudinary.com/dyafcag5y/image/upload/l_text:TakaoPGothic_60_bold:～#{@question.title.gsub(pattern, '')}～%0Aに挑戦したよ！,co_rgb:421,w_900,c_fit/v1752074826/h0rhydkkhqhzlqvt1rbk.png"
     set_meta_tags(og: { image: @url }, twitter: { image: @url })
 
     # セッションクリア

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -24,8 +24,7 @@ class QuestionsController < ApplicationController
   def show
     @question = Question.find(params[:id])
     pattern = /[\p{Emoji}\p{Emoji_Component}&&[:^ascii:]]/
-    @url = "https://res.cloudinary.com/dyafcag5y/image/upload/l_text:TakaoPGothic_60_bold:～#{@question.title.gsub(pattern, '')}～%0Aの問題を作ったよ！,co_rgb:FFF,w_900,c_fit/v1752043591/yng2jlr2e2w98soqvxje.png"
-
+    @url = "https://res.cloudinary.com/dyafcag5y/image/upload/l_text:TakaoPGothic_60_bold:～#{@question.title.gsub(pattern, '')}～%0Aの問題を作ったよ！,co_rgb:FFF,w_900,c_fit/v1752074827/kjwmtl03doe8m0ywkvvh.png"
     set_meta_tags(og: { image: @url }, twitter: { image: @url })
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -24,8 +24,10 @@ class QuestionsController < ApplicationController
   def show
     @question = Question.find(params[:id])
     pattern = /[\p{Emoji}\p{Emoji_Component}&&[:^ascii:]]/
-    @url = "https://res.cloudinary.com/dyafcag5y/image/upload/l_text:TakaoPGothic_60_bold:～#{@question.title.gsub(pattern, '')}～%0Aの問題を作ったよ！,co_rgb:FFF,w_900,c_fit/v1752074827/kjwmtl03doe8m0ywkvvh.png"
-    set_meta_tags(og: { image: @url }, twitter: { image: @url })
+    if current_user && current_user.own?(@question)
+      @url = "https://res.cloudinary.com/dyafcag5y/image/upload/l_text:TakaoPGothic_60_bold:～#{@question.title.gsub(pattern, '')}～%0Aの問題を作ったよ！,co_rgb:FFF,w_900,c_fit/v1752074827/kjwmtl03doe8m0ywkvvh.png"
+      set_meta_tags(og: { image: @url }, twitter: { image: @url })
+    end
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,10 @@ module ApplicationHelper
         type: "website",
         url: request.original_url,
         locale: "ja_JP"
+      },
+       twitter: {
+        card: "summary_large_image",
+        image: @url
       }
     }
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def default_meta_tags
+  def default_meta_tags(url: "https://res.cloudinary.com/dyafcag5y/image/upload/v1752075435/iyj9hdmhh8r4njmyrwwr.png")
     {
       site: "NeuroWord～仲間の言葉を見つけよう！～",
       title: "NeuroWord～仲間の言葉を見つけよう！～",
@@ -18,7 +18,7 @@ module ApplicationHelper
       },
        twitter: {
         card: "summary_large_image",
-        image: @url
+        image: url
       }
     }
   end


### PR DESCRIPTION
# 概要
- X(旧twitter)上でOGP画面が表示されなかったため、default_meta_tagにtwitter設定を追記しました。
- デフォルト（問題作成OGP・ゲーム結果OGP以外）のOGP画像を追加しました。
- 問題一覧のOGP画面について、問題作成者＝問題作成OGP/その他=デフォルトOGPが表示されるように修正しました。