### PR TITLE
fix:OGP画像ロジック修正（シェアボタンがあるページに依存→ポストのリンク先のページに依存に変更）

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -23,11 +23,6 @@ class QuestionsController < ApplicationController
 
   def show
     @question = Question.find(params[:id])
-    pattern = /[\p{Emoji}\p{Emoji_Component}&&[:^ascii:]]/
-    if current_user && current_user.own?(@question)
-      @url = "https://res.cloudinary.com/dyafcag5y/image/upload/l_text:TakaoPGothic_60_bold:～#{@question.title.gsub(pattern, '')}～%0Aの問題を作ったよ！,co_rgb:FFF,w_900,c_fit/v1752074827/kjwmtl03doe8m0ywkvvh.png"
-      set_meta_tags(og: { image: @url }, twitter: { image: @url })
-    end
   end
 
   def edit

--- a/app/views/games/result.html.erb
+++ b/app/views/games/result.html.erb
@@ -95,7 +95,7 @@
         <h3 class="card-title justify-center text-2xl">
         <div class="flex flex-wrap justify-center gap-4">
           <!-- Twitter/X シェア -->
-          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」に挑戦！\n正答率: #{@accuracy}% (#{@correct_clicks}/#{@total_clicks}クリック)\n完了問題: #{@total_matches}/#{@required_matches}問\n時間: #{sprintf('%02d:%02d', (@game_duration / 60).to_i, (@game_duration % 60).to_i)}\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape("#{request.base_url}/games/#{@question.id}")}", 
+          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」に挑戦！\n正答率: #{@accuracy}% (#{@correct_clicks}/#{@total_clicks}クリック)\n完了問題: #{@total_matches}/#{@required_matches}問\n時間: #{sprintf('%02d:%02d', (@game_duration / 60).to_i, (@game_duration % 60).to_i)}\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape("#{request.base_url}/games/#{@question.id}?from=result")}", 
                   target: "_blank",
                   class: "btn btn-neutral text-2xl shadow-xl mb-8" do %>
             <div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -29,7 +29,7 @@
         <h3 class="card-title justify-center text-2xl">
         <div class="flex flex-wrap justify-center gap-4">
           <!-- Twitter/X シェア -->
-          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」を作ったよ！\n挑戦してみてね🙌\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape("#{request.base_url}/games/#{@question.id}")}", 
+          <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("NeuroWordで「#{@question.title}」を作ったよ！\n挑戦してみてね🙌\n\n#仲間言葉探し #単語ゲーム")}&url=#{CGI.escape("#{request.base_url}/games/#{@question.id}?from=creator")}", 
                   target: "_blank",
                   class: "btn btn-neutral text-2xl shadow-xl mb-8" do %>
             <div>


### PR DESCRIPTION
# 概要
- 表示されるOGP画像が、シェアボタン元のURLを基準に生成される状態だったため、ポストのリンク先URLに依存となるように修正しました。