### PR TITLE
fix:問題一覧画面の表示ロジックを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "bullet"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -60,12 +60,13 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  gem "bullet"
 end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
-  gem "bullet"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
     brakeman (7.1.0)
       racc
     builder (3.3.0)
+    bullet (8.0.8)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -347,6 +350,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uniform_notifier (1.17.0)
     uri (1.0.3)
     useragent (0.16.11)
     warden (1.2.9)
@@ -379,6 +383,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman
+  bullet
   capybara
   cloudinary
   debug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
   def set_search
     # @search = Question.search(params[:q])
     @search = Question.ransack(params[:q]) # ransackメソッド推奨
-    @search_questions = @search.result.page(params[:page])
+    @search_questions = @search.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,9 +1,7 @@
 class QuestionsController < ApplicationController
   before_action :authenticate_user!, except: [ :index, :show ]
 
-  def index
-    @questions = Question.includes(:user).order(created_at: :desc).page(params[:page])
-  end
+  def index; end
 
   def new
     @question = Question.new

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,9 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "fingerprint": "1dd7f01ee59d92cd5034e72780d190aad003266142dc8b1b4aee7ba50df4da8c",
+      "note": "Kaminari and Ransack handle user input safely"
+    }
+  ]
+}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # While tests run files are not watched, reloading is not necessary.


### PR DESCRIPTION
# 概要
- 問題一覧画面の表示ロジックを修正しました。
　- Questionsコントローラーのindexアクション内の記述を削除しました。
　- Applicationのset_searchメソッド内を、作成日時降順となるよう修正しました。併せて、N+1問題を解消するよう`includes(:user)`も追記しました。
- brakeman警告の無視設定を追加しました。
- gem 'bullet'を追加しました。