### PR TITLE
update:brakemanの無視設定を更新

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -2,8 +2,38 @@
   "ignored_warnings": [
     {
       "warning_type": "Dynamic Render Path",
-      "fingerprint": "1dd7f01ee59d92cd5034e72780d190aad003266142dc8b1b4aee7ba50df4da8c",
-      "note": "Kaminari and Ransack handle user input safely"
+      "warning_code": 15,
+      "fingerprint": "1fd2ec2d867a3024acd56909aa0ad4269201520f4107399aa8c4bc7f000e4fa7",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/questions/index.html.erb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => Question.ransack(params[:q]).result(:distinct => true).includes(:user, :tags).order(:created_at => :desc).page(params[:page]), {})",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "QuestionsController",
+          "method": "index",
+          "line": 6,
+          "file": "app/controllers/questions_controller.rb",
+          "rendered": {
+            "name": "questions/index",
+            "file": "app/views/questions/index.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "questions/index"
+      },
+      "user_input": "params[:page]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
     }
-  ]
+  ],
+  "brakeman_version": "7.1.0"
 }


### PR DESCRIPTION
# 概要
- brakemanの無視設定を更新しました。
- 内容は #35 （[fix:brakemanの無視設定を追加](https://github.com/mo-land/NeuroWord/pull/35/commits/85290346f73515459d5c06f9ce7a7fc85c35e1d9)）と同様です。