### PR TITLE
fix:タグの長さを25字以内→20字以内に修正

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
-  validates :name, presence: true, length: { maximum: 25 }
+  validates :name, presence: true, length: { maximum: 20 }
   has_many :question_tags, dependent: :destroy
   has_many :questions, through: :question_tags
 end


### PR DESCRIPTION
## 概要
タグの長さが25字以内で登録できるようになっていたため、20字以内で登録できるように修正しました。
（placeholderは20字以内と記載）