### PR TITLE
update:タイトルを動的に出力する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 module ApplicationHelper
+  def page_title(title = '')
+    base_title = 'NeuroWord～仲間の言葉を見つけよう！～'
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
+  
   def default_meta_tags(url: "https://res.cloudinary.com/dyafcag5y/image/upload/v1752075435/iyj9hdmhh8r4njmyrwwr.png")
     {
       site: "NeuroWord～仲間の言葉を見つけよう！～",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "NeuroWord~仲間の言葉を見つけよう！~" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+     <title><%= page_title(yield(:title)) %></title>    <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## Issue
#130
※Closeは、過去作成ページの各タイトル書式を統一してからとする予定

## 概要
下記の実装を行いました。
いずれも、今後追加作成するページのタイトルに統一感を持たせるための対応です。
- helperにタイトルを動的に出力するメソッドを定義する
- ベースタイトルをアプリケーション全体に適応する

## 今後の予定
- 過去作成分含む各ページのタイトル書式等に統一感を出す（左上にシンプルに表示）