### PR TITLE
add: マイページTOP画面（プロフィール・自作問題参照可能）

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,18 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_user
+
+  def mypage
+    @questions = @user.questions.includes([:tags]).page(params[:page])
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+
+  def set_user
+    @user = current_user
+  end
+end

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -6,7 +6,7 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
-<div class="bg-base-200 join text-xs mx-auto flex justify-center">
+<div class="join text-xs mx-auto flex justify-center">
   <%= paginator.render do -%>
     <nav class="pagination" role="navigation" aria-label="pager">
       <%# first_page_tag unless current_page.first? %>

--- a/app/views/shared/_dock.html.erb
+++ b/app/views/shared/_dock.html.erb
@@ -2,29 +2,15 @@
   <%= link_to questions_path, class: "hover:dock-active" do %>
     <i class="fa-solid fa-magnifying-glass" viewBox="0 0 24 24"></i>
     <span class="dock-label">問題を探す</span>
-   <% end %>
-  
-  <% if user_signed_in? %>
-    <%= link_to new_question_path, class: "hover:dock-active" do %>
-      <i class="fa-solid fa-circle-plus" viewBox="0 0 24 24"></i>
-      <span class="dock-label">新しい問題を作る</span>
-    <% end %>
+  <% end %>
 
-    <%= link_to '#', class: "hover:dock-active" do %>
-      <i class="fa-solid fa-user" viewBox="0 0 24 24"></i>
-      <span class="dock-label">【準備中】</span>
-      <span class="dock-label">マイページ</span>
-    <% end %>
-  <% else %>
-    <%= link_to new_user_session_path, class: "hover:dock-active" do %>
-      <i class="fa-solid fa-circle-plus" viewBox="0 0 24 24"></i>
-      <span class="dock-label">【要ログイン】</span>
-      <span class="dock-label">新しい問題を作る</span>
-    <% end %>
-    <%= link_to '#', class: "hover:dock-active" do %>
-      <i class="fa-solid fa-user" viewBox="0 0 24 24"></i>
-      <span class="dock-label">【準備中・要ログイン】</span>
-      <span class="dock-label">マイページ</span>
-    <% end %> 
+  <%= link_to new_question_path, class: "hover:dock-active" do %>
+    <i class="fa-solid fa-circle-plus" viewBox="0 0 24 24"></i>
+    <span class="dock-label">新しい問題を作る</span>
+  <% end %>
+  
+  <%= link_to mypage_user_path, class: "hover:dock-active" do %>
+    <i class="fa-solid fa-user" viewBox="0 0 24 24"></i>
+    <span class="dock-label">マイページ</span>
   <% end %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,22 +1,70 @@
-<div class="navbar  bg-base-300 shadow-sm">
-  <div class="navbar-start">
+<div class="navbar bg-base-300 shadow-sm flex justify-between">
+  <div class="navbar-start flex items-center">
     <%= link_to '/', class: 'flex items-center space-x-2' do %>
       <%= image_tag 'NeuroWord_logo.png', class: 'w-auto' %>
     <% end %>
+    <!-- PC用ヘッダーメニュー（ログインユーザー） -->
+    <% if user_signed_in? %>
+      <div class="hidden lg:flex">
+        <ul class="menu menu-horizontal px-1">
+          <li><a>準備中</a></li>
+          <li>
+            <details class="relative">
+              <summary>準備中</summary>
+              <ul class="p-2 absolute left-0 mt-2 bg-base-100 rounded-box shadow z-[9999]">
+                <li><a>準備中</a></li>
+                <li><a>準備中</a></li>
+              </ul>
+            </details>
+          </li>
+          <li><%= link_to 'お問い合わせ', 'https://x.com/MO_study2408' %></li>
+        </ul>
+      </div>
+    <% end %>
   </div>
 
-  <div class="navbar-end ml-4">
+
+  <!-- スマホメニュー（ログインユーザー） -->
   <% if user_signed_in? %>
-        <div class="dropdown dropdown-end">
-          <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"> <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" /> </svg>
-          </div>
-          <ul
-            tabindex="0"
-            class="menu menu-sm dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow">
+    <div class="navbar-end ml-4 dropdown dropdown-end lg:hidden">
+      <ul class="menu menu-horizontal px-1">
+        <li>
+          <details>
+            <summary><%= "#{current_user.name}さん" %></summary>
+            <ul class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" >
+              <li><a>準備中</a></li>
+              <li><a>準備中</a>
+                <ul class="p-2">
+                  <li><a>準備中</a></li>
+                  <li><a>準備中</a></li>
+                </ul>
+              </li>
+              <li><%= link_to 'お問い合わせ', 'https://x.com/MO_study2408' %></li>
+              <li>
+                <%= link_to destroy_user_session_path, class: "text-warning", data: { turbo_method: :delete } do %>
+                  <i class="fa-solid fa-right-from-bracket" viewBox="0 0 24 24"></i>
+                  <span>ログアウト</span>
+                <% end %>
+              </li>
+              <li></li>
+              <li></li>
+              <li><div div class='copyright'>
+                <p>Copyright © 2025 NeuroWord～仲間の言葉を見つけよう！～</p>
+              </div></li>
+            </ul>
+          </details>
+        </li>
+      </ul>
+    </div>
+    <!-- PC版ユーザーメニュー -->
+    <div class="navbar-end dropdown dropdown-end hidden lg:flex">
+      <ul class="menu menu-horizontal px-1">
+        <li>
+        <details>
+          <summary class="text-xl"><%= "#{current_user.name} さん" %></summary>
+          <ul class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" >
             <li><a>準備中</a></li>
-            <li>
-              <a>準備中</a>
+            <li><a>準備中</a>
               <ul class="p-2">
                 <li><a>準備中</a></li>
                 <li><a>準備中</a></li>
@@ -35,42 +83,23 @@
               <p>Copyright © 2025 NeuroWord～仲間の言葉を見つけよう！～</p>
             </div></li>
           </ul>
-        </div>
-        <div class="navbar-center hidden lg:flex">
-          <ul class="menu menu-horizontal px-1">
-            <li><a>準備中</a></li>
-            <li>
-              <details class="relative">
-                <summary>準備中</summary>
-                <ul class="p-2 absolute left-0 mt-2 bg-base-100 rounded-box shadow z-[9999]">
-                  <li><a>準備中</a></li>
-                  <li><a>準備中</a></li>
-                </ul>
-              </details>
-            </li>
-            <li><%= link_to 'お問い合わせ', 'https://x.com/MO_study2408' %></li>
-            <li>
-              <%= link_to destroy_user_session_path, class: "text-warning", data: { turbo_method: :delete } do %>
-                <i class="fa-solid fa-right-from-bracket" viewBox="0 0 24 24"></i>
-                <span>ログアウト</span>
-              <% end %>
-            </li>
-          </ul>
-        </div>
-      </li>
-    <% else %>
-      <div class="flex-none">
-        <ul class="menu menu-horizontal md:px-1">
-          <li class="sm:mx-1 md:mx-2">
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary sm:btn-sm md:btn-md" %>
-          </li>
-          <li class="sm:mx-1 md:mx-2">
-            <%= link_to "新規登録", new_user_registration_path, class: "btn btn-secondary sm:btn-sm md:btn-md" %>
-          </li>
-        </ul>
-      </div>
-    <% end %>
-  </div>
+        </details>
+        </li>
+      </ul>
+    </div>
+  <% else %>
+    <!-- 共通_ログイン前メニュー -->
+    <div class="flex-none">
+      <ul class="menu menu-horizontal md:px-1">
+        <li class="sm:mx-1 md:mx-2">
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-primary sm:btn-sm md:btn-md" %>
+        </li>
+        <li class="sm:mx-1 md:mx-2">
+          <%= link_to "新規登録", new_user_registration_path, class: "btn btn-secondary sm:btn-sm md:btn-md" %>
+        </li>
+      </ul>
+    </div>
+  <% end %>
 </div>
 
 

--- a/app/views/users/_user_questions.html.erb
+++ b/app/views/users/_user_questions.html.erb
@@ -1,0 +1,12 @@
+
+  <%= paginate @questions %>
+
+  <div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-12 mx-auto max-w-screen-6xl py-8 items-stretch">
+  <!-- 問題一覧 -->
+    <% if @questions.present? %>
+      <%= render @questions %>
+    <% else %>
+      <div class="m-8">問題がありません</div>
+    <% end %>
+  </div>
+  <%= paginate @questions %>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,0 +1,40 @@
+<h1 class="text-2xl font-bold text-left p-6"><%= t('.title') %></h1>
+<div class="max-w-3xl mx-auto px-4">
+
+<!-- %=# link_to t('defaults.edit'), edit_profile_path, class: 'btn btn-success' % -->
+
+  <div class="card bg-base-100 shadow-sm">
+    <div class="card-body">
+      <div class="md:flex items-center gap-4 mb-2">
+        <div class="flex items-center gap-2 mr-6">
+          <i class="fa-solid fa-user" aria-hidden="true"></i>
+          <h2 class="text-l font-bold"><%= t('.user_information') %></h2>
+        </div>
+        <div>
+          <p class="text-xl font-semibold"><%= current_user.name %></p>
+          <div class="flex items-center gap-2">
+            <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+            <p><%= current_user.email %></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- name of each tab group should be unique -->
+<div class="tabs tabs-lift mt-3 p-4">
+  <input type="radio" name="my_tabs_3" class="tab" aria-label=<%= t('.user_questions') %> checked="checked" />
+  <div class="tab-content bg-base-100 border-base-300 p-6">
+    <%= render 'user_questions' %>
+  </div>
+
+  <input type="radio" name="my_tabs_3" class="tab" aria-label=<%= t('.user_lists') %> />
+  <div class="tab-content bg-base-100 border-base-300 p-6">
+    準備中！お楽しみに～～！
+  </div>
+
+  <input type="radio" name="my_tabs_3" class="tab" aria-label=<%= t('.game_records') %> />
+  <div class="tab-content bg-base-100 border-base-300 p-6">
+    準備中！お楽しみに～～！
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,3 +25,10 @@ ja:
       title: 問題一覧
     edit:
       title: 問題編集
+  users:
+    mypage:
+      title: マイページ
+      user_information: ユーザー情報
+      user_questions: 作った問題
+      user_lists: リスト
+      game_records: プレイ履歴

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,12 @@ Rails.application.routes.draw do
 
   get "search_tag"=>"questions#search_tag"
 
+  resource :user, only: [:edit, :update] do
+    member do
+      get :mypage  # 必要に応じて
+    end
+  end
+
   resources :questions, only: %i[index new create show edit update destroy] do
     resources :card_sets
   end


### PR DESCRIPTION
## Issue
close: #80 

# 概要
- dockからマイページに遷移し、自分のプロフィールと自作問題を確認できるようにしました。
- ヘッダーからログインユーザー名を確認できるようにしました。

# 備考
- ヘッダーからのマイページ遷移は、 #132 で対応予定。