### PR TITLE
add: ユーザー名変更機能

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -19,6 +19,49 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
+  def edit
+    if turbo_frame_request?
+      # Turbo Frameならフォーム表示
+      super
+    else
+      # 通常遷移ならマイページへ
+      redirect_to mypage_user_path, alert: "都合により、マイページを再読み込みしました。<br>ユーザー編集の場合は再度「編集」ボタンを押してください。"
+    end
+  end
+
+  # PUT /resource
+  # We need to use a copy of the resource because we don't want to change
+  # the current user in place.
+  def update
+    self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
+    prev_unconfirmed_email = resource.unconfirmed_email if resource.respond_to?(:unconfirmed_email)
+
+    resource_updated = update_resource(resource, account_update_params)
+    yield resource if block_given?
+    if resource_updated
+      set_flash_message_for_update(resource, prev_unconfirmed_email)
+      bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
+
+      # claudeで変更（明示的なTurbo化）
+      # respond_with resource, location: after_update_path_for(resource)
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to after_update_path_for(resource) }
+      end
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+
+　　　# claudeで変更（明示的なTurbo化）
+      # respond_with resource
+      respond_to do |format|
+        format.turbo_stream { render :update, status: :unprocessable_entity }
+        format.html { render :edit, status: :unprocessable_entity }
+      end
+    end
+    current_user.reload
+  end
+
   # PUT /resource
   # def update
   #   super
@@ -69,5 +112,21 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # 編集後のリダイレクト先を指定するメソッド
   def after_update_path_for(resource)
     mypage_user_path(resource)
+  end
+
+  private
+
+  def set_flash_message_for_update(resource, prev_unconfirmed_email)
+    return unless is_flashing_format?
+
+    flash_key = if update_needs_confirmation?(resource, prev_unconfirmed_email)
+      :update_needs_confirmation
+    elsif sign_in_after_change_password?
+      :updated
+    else
+      :updated_but_not_signed_in
+    end
+    # set_flash_message :notice, flash_key
+    flash.now[:notice] = I18n.t("devise.registrations.#{flash_key}")
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -59,4 +59,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def after_inactive_sign_up_path_for(resource)
     root_path
   end
+
+  protected
+  # パスワードなしでユーザー情報を更新
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+
+  # 編集後のリダイレクト先を指定するメソッド
+  def after_update_path_for(resource)
+    mypage_user_path(resource)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,10 +8,6 @@ class UsersController < ApplicationController
 
   private
 
-  def user_params
-    params.require(:user).permit(:name, :email)
-  end
-
   def set_user
     @user = current_user
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,4 +27,8 @@ module ApplicationHelper
       }
     }
   end
+
+   def turbo_stream_flash
+    turbo_stream.update "flash", partial: "shared/flash_messages"
+  end
 end

--- a/app/views/devise/registrations/_edit_form.html.erb
+++ b/app/views/devise/registrations/_edit_form.html.erb
@@ -1,33 +1,41 @@
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <fieldset class="fieldset pb-2">
-      <%= f.label :name, class: "fieldset-legend" %>
-      <%= f.text_field :name, class: "input", placeholder: "ユーザー名を入力", autofocus: true %>
-    </fieldset>
+<%= turbo_frame_tag current_user do %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+    <div class="card w-93 card-xs shadow-sm px-6">
+      <div class="card-body">
+        <h3 class="text-lg font-bold text-left pt-2"><%= t('devise.registrations.edit.title') %></h3>
+        <fieldset class="fieldset pb-2">
+          <%= f.label :name, class: "fieldset-legend" %>
+          <%= f.text_field :name, class: "input", placeholder: "ユーザー名を入力", autofocus: true %>
+        </fieldset>
 <%
 =begin%>
-    <fieldset class="fieldset">
-      <%= f.label :email, class: "fieldset-legend" %>
-      <%= f.email_field :email, class: "input", autocomplete: "email", placeholder: "例：sample@example.com"  %>
-    </fieldset>
+        <fieldset class="fieldset">
+          <%= f.label :email, class: "fieldset-legend" %>
+          <%= f.email_field :email, class: "input", autocomplete: "email", placeholder: "例：sample@example.com"  %>
+        </fieldset>
 
-    <fieldset class="fieldset">
-      <%= f.label :password, class: "fieldset-legend" %>
-      <% if @minimum_password_length %>
-      <em>(英数字<%= @minimum_password_length %> 文字以上)</em>
-      <% end %><br />
-      <%= f.password_field :password, class: "input", placeholder: "パスワードを入力", autocomplete: "new-password" %>
-    </fieldset>
+        <fieldset class="fieldset">
+          <%= f.label :password, class: "fieldset-legend" %>
+          <% if @minimum_password_length %>
+          <em>(英数字<%= @minimum_password_length %> 文字以上)</em>
+          <% end %><br />
+          <%= f.password_field :password, class: "input", placeholder: "パスワードを入力", autocomplete: "new-password" %>
+        </fieldset>
 
-    <fieldset class="fieldset">
-      <%= f.label :password_confirmation, class: "fieldset-legend" %>
-      <%= f.password_field :password_confirmation, class: "input", placeholder: "もう1度パスワードを入力", autocomplete: "new-password" %>
-    </fieldset>
+        <fieldset class="fieldset">
+          <%= f.label :password_confirmation, class: "fieldset-legend" %>
+          <%= f.password_field :password_confirmation, class: "input", placeholder: "もう1度パスワードを入力", autocomplete: "new-password" %>
+        </fieldset>
 <%
 =end%>
-
-    <div class="actions">
-      <%= f.submit class:"btn btn-primary mb-2" %>
+        <div class="flex items-end gap-2 justify-end">
+          <div class="actions">
+            <%= f.submit "更新", class:"btn btn-primary md:justify-end" %>
+          </div>
+          <%= link_to "戻る", mypage_user_path, class:"btn btn-outline md:justify-end" %>
+        </div>
+      </div>
     </div>
+  <% end %>
 <% end %>

--- a/app/views/devise/registrations/_edit_form.html.erb
+++ b/app/views/devise/registrations/_edit_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <fieldset class="fieldset pb-2">
+      <%= f.label :name, class: "fieldset-legend" %>
+      <%= f.text_field :name, class: "input", placeholder: "ユーザー名を入力", autofocus: true %>
+    </fieldset>
+<%
+=begin%>
+    <fieldset class="fieldset">
+      <%= f.label :email, class: "fieldset-legend" %>
+      <%= f.email_field :email, class: "input", autocomplete: "email", placeholder: "例：sample@example.com"  %>
+    </fieldset>
+
+    <fieldset class="fieldset">
+      <%= f.label :password, class: "fieldset-legend" %>
+      <% if @minimum_password_length %>
+      <em>(英数字<%= @minimum_password_length %> 文字以上)</em>
+      <% end %><br />
+      <%= f.password_field :password, class: "input", placeholder: "パスワードを入力", autocomplete: "new-password" %>
+    </fieldset>
+
+    <fieldset class="fieldset">
+      <%= f.label :password_confirmation, class: "fieldset-legend" %>
+      <%= f.password_field :password_confirmation, class: "input", placeholder: "もう1度パスワードを入力", autocomplete: "new-password" %>
+    </fieldset>
+<%
+=end%>
+
+    <div class="actions">
+      <%= f.submit class:"btn btn-primary mb-2" %>
+    </div>
+<% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,14 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h1 class="text-2xl font-bold text-left p-6"><%= t('.title') %></h1>
+<div class='px-6'>
+  <%= render 'edit_form', user: @user %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%
+=begin%>
+  <h3>Cancel my account</h3>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+<%
+=end%>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+  <%= link_to "戻る", :back, class:"btn btn-outline mb-2" %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,6 @@
-<h1 class="text-2xl font-bold text-left p-6"><%= t('.title') %></h1>
 <div class='px-6'>
   <%= render 'edit_form', user: @user %>
-
+</div>
 <%
 =begin%>
   <h3>Cancel my account</h3>
@@ -10,5 +9,3 @@
 <%
 =end%>
 
-  <%= link_to "戻る", :back, class:"btn btn-outline mb-2" %>
-</div>

--- a/app/views/devise/registrations/update.turbo_stream.erb
+++ b/app/views/devise/registrations/update.turbo_stream.erb
@@ -1,0 +1,10 @@
+<%= turbo_stream.replace "header_name_pc" do %>
+  <%= render "shared/header_name" %>
+<% end %>
+<%= turbo_stream.replace "header_name_sp" do %>
+  <%= render "shared/header_name" %>
+<% end %>
+<%= turbo_stream.replace current_user do %>
+  <%= render "users/profile" %>
+<% end %>
+<%= turbo_stream_flash %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,9 @@
 
   <body>
     <%= render 'shared/header' %>
-    <%= render 'shared/flash_messages' %>
+    <div id="flash">
+      <%= render 'shared/flash_messages' %>
+    </div>
     <%= yield %>
     <%= render 'shared/footer' %>
     <%= render 'shared/dock' %>

--- a/app/views/shared/_flash_messages.html.erb
+++ b/app/views/shared/_flash_messages.html.erb
@@ -6,6 +6,6 @@
     else "alert-info"
   end %>
   <div class="alert <%= alert_class %> shadow-lg my-2">
-    <span><%= message %></span>
+    <span><%= sanitize message, tags: %w(br) %></span>
   </div>
 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -30,7 +30,11 @@
       <ul class="menu menu-horizontal px-1">
         <li>
           <details>
-            <summary><%= "#{current_user.name}さん" %></summary>
+          <summary class="text-xl">
+            <%= turbo_frame_tag "header_name_sp" do %>
+              <%= render "shared/header_name" %>
+            <% end %>
+          </summary>
             <ul class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" >
               <li><a>準備中</a></li>
               <li><a>準備中</a>
@@ -61,7 +65,11 @@
       <ul class="menu menu-horizontal px-1">
         <li>
         <details>
-          <summary class="text-xl"><%= "#{current_user.name} さん" %></summary>
+          <summary class="text-xl">
+            <%= turbo_frame_tag "header_name_pc" do %>
+              <%= render "shared/header_name" %>
+            <% end %>
+          </summary>
           <ul class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" >
             <li><a>準備中</a></li>
             <li><a>準備中</a>

--- a/app/views/shared/_header_name.html.erb
+++ b/app/views/shared/_header_name.html.erb
@@ -1,0 +1,1 @@
+<%= "#{current_user.name} さん" %>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -1,0 +1,17 @@
+ <div class="card w-93 bg-base-100 card-xs shadow-sm px-3">
+      <div class="card-body">
+        <div>
+          <div class="flex items-center gap-2">
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <h2 class="text-xl font-semibold"><%= current_user.name %></h2>
+          </div>
+          <div class="flex items-center gap-2">
+            <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+            <h3 class="text-lg"><%= current_user.email %></h3>
+          </div>
+        </div>
+        <div class="justify-end card-actions">
+          <%= link_to t('defaults.edit'), edit_user_registration_path, class: 'btn btn-success' %>
+        </div>
+      </div>
+    </div>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,26 +1,26 @@
 <h1 class="text-2xl font-bold text-left p-6"><%= t('.title') %></h1>
 <div class="max-w-3xl mx-auto px-4">
 
-<!-- %=# link_to t('defaults.edit'), edit_profile_path, class: 'btn btn-success' % -->
 
-  <div class="card bg-base-100 shadow-sm">
-    <div class="card-body">
-      <div class="md:flex items-center gap-4 mb-2">
-        <div class="flex items-center gap-2 mr-6">
-          <i class="fa-solid fa-user" aria-hidden="true"></i>
-          <h2 class="text-l font-bold"><%= t('.user_information') %></h2>
-        </div>
+  <div class="card bg-base-100 card-xs shadow-sm px-32">
+  <div class="card-body">
         <div>
-          <p class="text-xl font-semibold"><%= current_user.name %></p>
+          <div class="flex items-center gap-2">
+            <i class="fa-solid fa-user" aria-hidden="true"></i>
+            <h2 class="text-xl font-semibold"><%= current_user.name %></h2>
+          </div>
           <div class="flex items-center gap-2">
             <i class="fa-solid fa-envelope" aria-hidden="true"></i>
             <p><%= current_user.email %></p>
           </div>
         </div>
-      </div>
+    <div class="justify-end card-actions">
+      <%= link_to t('defaults.edit'), '#', class: 'btn btn-success' %>
     </div>
   </div>
 </div>
+</div>
+
 <!-- name of each tab group should be unique -->
 <div class="tabs tabs-lift mt-3 p-4">
   <input type="radio" name="my_tabs_3" class="tab" aria-label=<%= t('.user_questions') %> checked="checked" />

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -2,24 +2,9 @@
 <div class="md:justify-self-start">
   <div class="max-w-3xl mx-auto px-4">
 
-
-    <div class="card w-93 bg-base-100 card-xs shadow-sm px-3">
-      <div class="card-body">
-        <div>
-          <div class="flex items-center gap-2">
-            <i class="fa-solid fa-user" aria-hidden="true"></i>
-            <h2 class="text-xl font-semibold"><%= current_user.name %></h2>
-          </div>
-          <div class="flex items-center gap-2">
-            <i class="fa-solid fa-envelope" aria-hidden="true"></i>
-            <h3 class="text-lg"><%= current_user.email %></h3>
-          </div>
-        </div>
-        <div class="justify-end card-actions">
-          <%= link_to t('defaults.edit'), edit_user_registration_path, class: 'btn btn-success' %>
-        </div>
-      </div>
-    </div>
+    <%= turbo_frame_tag current_user do %>
+      <%= render "profile" %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,9 +1,10 @@
 <h1 class="text-2xl font-bold text-left p-6"><%= t('.title') %></h1>
-<div class="max-w-3xl mx-auto px-4">
+<div class="md:justify-self-start">
+  <div class="max-w-3xl mx-auto px-4">
 
 
-  <div class="card bg-base-100 card-xs shadow-sm px-32">
-  <div class="card-body">
+    <div class="card w-93 bg-base-100 card-xs shadow-sm px-3">
+      <div class="card-body">
         <div>
           <div class="flex items-center gap-2">
             <i class="fa-solid fa-user" aria-hidden="true"></i>
@@ -11,14 +12,15 @@
           </div>
           <div class="flex items-center gap-2">
             <i class="fa-solid fa-envelope" aria-hidden="true"></i>
-            <p><%= current_user.email %></p>
+            <h3 class="text-lg"><%= current_user.email %></h3>
           </div>
         </div>
-    <div class="justify-end card-actions">
-      <%= link_to t('defaults.edit'), '#', class: 'btn btn-success' %>
+        <div class="justify-end card-actions">
+          <%= link_to t('defaults.edit'), edit_user_registration_path, class: 'btn btn-success' %>
+        </div>
+      </div>
     </div>
   </div>
-</div>
 </div>
 
 <!-- name of each tab group should be unique -->

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -98,7 +98,7 @@ ja:
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
-        title: "%{resource}編集"
+        title: "ユーザー編集"
         unhappy: 気に入りません
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -2,6 +2,7 @@ ja:
   defaults:
     create: 作成
     post: 投稿
+    edit: 編集
     delete_confirm: 削除しますか？
     flash_message:
       created: "%{item}を作成しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   get "search_tag"=>"questions#search_tag"
 
-  resource :user, only: [ :edit, :update ] do
+  resource :user, only: %i[] do
     member do
       get :mypage  # 必要に応じて
     end


### PR DESCRIPTION
## Issue
close: #81 

# 概要
- マイページから、ユーザー名の変更ができるようにしました。
- Turboを活用し、以下の画面遷移・更新を非同期化しました。
  - TurboFrames（ユーザー編集画面表示）
  - TurboStreams（更新完了メッセージ・ヘッダーのユーザー名）

# 備考・後でやること
-  ヘッダーのユーザー名は、 #116 で画像アイコンにアップデート予定。
- Stimulasは未対応。対応するかどうか含め、MVP後に検討予定。（issue: #136 ）
- 【一時対処済】更新完了メッセージが表示された状態で再度編集しようとすると、非同期で画面遷移しない問題あり。
   → ユーザー編集画面にTurboFramesを使わず遷移した場合は、マイページに自動遷移し改めてユーザー編集を行うようメッセージを表示させることとしています。
  [![Image from Gyazo](https://i.gyazo.com/8a40a89b572bf12210906c9ef9aad28f.png)](https://gyazo.com/8a40a89b572bf12210906c9ef9aad28f)