### PR TITLE
add: 修正依頼投稿画面にオートコンプリート機能を追加

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -84,6 +84,13 @@ class QuestionsController < ApplicationController
     end
   end
 
+  def autocomplete
+    @questions = Question.where("title like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def question_params

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
 
 const application = Application.start()
+application.register('autocomplete', Autocomplete)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -3,7 +3,7 @@ class Question < ApplicationRecord
   has_many :question_tags, dependent: :destroy
   has_many :tags, through: :question_tags
 
-  validates :title, presence: true, length: { maximum: 40 }
+  validates :title, uniqueness: true, presence: true, length: { maximum: 40 }
   validates :description, presence: true, length: { maximum: 150 }
   # validate :minimum_card_sets_required, on: :create
   validate :maximum_total_cards_limit

--- a/app/views/questions/autocomplete.html.erb
+++ b/app/views/questions/autocomplete.html.erb
@@ -1,0 +1,5 @@
+<% @questions.each do |question| %>
+  <li class="flex w-full items-center text-sm py-2 px-3 hover:bg-amber-100" role="option" data-autocomplete-value="<%= question.id %>" data-autocomplete-label="<%= question.title %>">
+    <%= question.title %>
+  </li>
+<% end %>

--- a/app/views/requests/_question_search_form.html.erb
+++ b/app/views/requests/_question_search_form.html.erb
@@ -1,0 +1,7 @@
+<%= search_form_for @search, url: questions_path do |f| %>
+  <div data-controller="autocomplete" data-autocomplete-url-value="<%= autocomplete_questions_path %>" role="combobox">
+    <%= f.search_field :title_or_description_or_user_name_cont, placeholder: t('.placeholder'), class: "input input-bordered w-full", data: { autocomplete_target: 'input' } %>
+    <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+    <ul class="list-group" data-autocomplete-target="results"></ul>
+  </div>
+<% end %>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -1,15 +1,15 @@
 <div class="container mx-auto px-4 py-8">
   <div class="grid grid-cols-1 lg:grid-cols-8">
     <div class="lg:col-start-2 lg:col-span-6">
+      <div class="card bg-base-100 shadow-lg p-4">
 <h1 class="text-2xl font-bold text-left px-6 pt-6"><%= t('.title') %></h1>
-      <div class="card bg-base-100 shadow-lg">
         <div class="card-body">
           <%= form_with model: @request, class: "new_request" do |f| %>
             <%= render 'shared/error_messages', object: f.object %>
 
             <div class="form-control mb-4">
               <%= f.label :question_title %>
-              <%= f.text_field :question_title, class: "input input-bordered w-full" %>
+              <%= render 'requests/question_search_form' %>
             </div>
             <div class="form-control mb-4">
               <%= f.label :title %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -44,3 +44,5 @@ ja:
       post: 投稿する
     request_btn:
       request: 【準備中】修正依頼
+    question_search_form:
+      placeholder: 問題タイトルを入力して選択

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
 
   resources :questions, only: %i[index new create show edit update destroy] do
     resources :card_sets
+    collection do
+      get :autocomplete
+    end
   end
 
   # ゲーム関連ルート

--- a/db/migrate/20250903143946_add_unique_index_to_questions_title.rb
+++ b/db/migrate/20250903143946_add_unique_index_to_questions_title.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToQuestionsTitle < ActiveRecord::Migration[7.2]
+  def change
+    add_index :questions, :title, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_01_130153) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_03_143946) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_01_130153) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["title"], name: "index_questions_on_title", unique: true
     t.index ["user_id"], name: "index_questions_on_user_id"
   end
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
-    "@hotwired/turbo-rails": "^8.0.16"
+    "@hotwired/turbo-rails": "^8.0.16",
+    "stimulus-autocomplete": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,3 +180,8 @@ esbuild@^0.25.5:
     "@esbuild/win32-arm64" "0.25.5"
     "@esbuild/win32-ia32" "0.25.5"
     "@esbuild/win32-x64" "0.25.5"
+
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==


### PR DESCRIPTION
## Issue
close: #145 

# 概要
- 修正依頼投稿画面で、問題タイトルをオートコンプリートで選択できるようにしました。
  - [stimulus-autocomplete](https://github.com/afcapel/stimulus-autocomplete)を使用
- 問題タイトルにユニーク制約を追加しました。

# 備考・後でやること
- request#createの機能追加は、https://github.com/mo-land/NeuroWord/issues/146 で対応予定