### PR TITLE
add: 修正依頼投稿機能を追加

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -7,5 +7,22 @@ class RequestsController < ApplicationController
 
   def new
     @request = Request.new
+    @search = Question.ransack(params[:q])
+  end
+
+  def create
+    @request = current_user.requests.build(request_params)
+    if @request.save
+      redirect_to requests_path, success: t("defaults.flash_message.created", item: Request.model_name.human)
+    else
+      flash.now[:danger] = t("defaults.flash_message.not_created", item: Request.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def request_params
+    params.require(:request).permit(:title, :content, :question_id)
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("card-set-form", CardSetFormController)
 
 import GameController from "./game_controller"
 application.register("game", GameController)
+
+import RequestFormController from "./request_form_controller"
+application.register("request-form", RequestFormController)

--- a/app/javascript/controllers/request_form_controller.js
+++ b/app/javascript/controllers/request_form_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+  connect() {
+    // オートコンプリートの結果リストをクリックしたときのイベントリスナー
+    this.element.addEventListener('click', (event) => {
+      const listItem = event.target.closest('li[data-question-id]')
+      if (listItem) {
+        const questionId = listItem.dataset.questionId
+        const hiddenField = document.getElementById('request_question_id')
+        if (hiddenField) {
+          hiddenField.value = questionId
+        }
+      }
+    })
+  }
+
+  disconnect() {
+    // クリーンアップ処理
+  }
+}

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,6 +4,9 @@ class Request < ApplicationRecord
 
   has_many :request_responses, dependent: :destroy
 
+  validates :title, presence: true, length: { maximum: 60 }
+  validates :content, presence: true, length: { maximum: 500 }
+
   enum status: { incompleted: 0, completed: 1 }
 
   # Runsackホワイトリスト

--- a/app/views/questions/autocomplete.html.erb
+++ b/app/views/questions/autocomplete.html.erb
@@ -1,5 +1,9 @@
 <% @questions.each do |question| %>
-  <li class="flex w-full items-center text-sm py-2 px-3 hover:bg-amber-100" role="option" data-autocomplete-value="<%= question.id %>" data-autocomplete-label="<%= question.title %>">
-    <%= question.title %>
-  </li>
-<% end %>
+    <li class="flex w-full items-center text-sm py-2 px-3 hover:bg-amber-100"
+        role="option"
+        data-autocomplete-value="<%= question.title %>"
+        data-autocomplete-label="<%= question.title %>"
+        data-question-id="<%= question.id %>">
+      <%= question.title %>
+    </li>
+  <% end %>

--- a/app/views/requests/_question_search_form.html.erb
+++ b/app/views/requests/_question_search_form.html.erb
@@ -3,8 +3,7 @@
 <div data-controller="autocomplete request-form"
       data-autocomplete-url-value="<%= autocomplete_questions_path %>"
       data-autocomplete-hidden-field="#request_question_id">
-  <input placeholder="<%= t('.placeholder') %>"
-         class="input input-bordered w-full"
+  <input class="input input-bordered w-full"
          autocomplete="off"
          data-autocomplete-target="input"
          type="search" />

--- a/app/views/requests/_question_search_form.html.erb
+++ b/app/views/requests/_question_search_form.html.erb
@@ -1,7 +1,12 @@
-<%= search_form_for @search, url: questions_path do |f| %>
-  <div data-controller="autocomplete" data-autocomplete-url-value="<%= autocomplete_questions_path %>" role="combobox">
-    <%= f.search_field :title_or_description_or_user_name_cont, placeholder: t('.placeholder'), class: "input input-bordered w-full", data: { autocomplete_target: 'input' } %>
-    <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
-    <ul class="list-group" data-autocomplete-target="results"></ul>
-  </div>
-<% end %>
+
+
+<div data-controller="autocomplete request-form"
+      data-autocomplete-url-value="<%= autocomplete_questions_path %>"
+      data-autocomplete-hidden-field="#request_question_id">
+  <input placeholder="<%= t('.placeholder') %>"
+         class="input input-bordered w-full"
+         autocomplete="off"
+         data-autocomplete-target="input"
+         type="search" />
+  <ul class="list-group" data-autocomplete-target="results"></ul>
+</div>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -9,6 +9,9 @@
 
             <div class="form-control mb-4">
               <%= f.label :question_title %>
+              <div class="text-xs text-base-content/70">
+                <%= t('.description') %>
+              </div>
               <%= render 'requests/question_search_form' %>
               <%= f.hidden_field :question_id %>
             </div>

--- a/app/views/requests/new.html.erb
+++ b/app/views/requests/new.html.erb
@@ -4,12 +4,13 @@
       <div class="card bg-base-100 shadow-lg p-4">
 <h1 class="text-2xl font-bold text-left px-6 pt-6"><%= t('.title') %></h1>
         <div class="card-body">
-          <%= form_with model: @request, class: "new_request" do |f| %>
+          <%= form_with model: @request, class: "new_request", local: true do |f| %>
             <%= render 'shared/error_messages', object: f.object %>
 
             <div class="form-control mb-4">
               <%= f.label :question_title %>
               <%= render 'requests/question_search_form' %>
+              <%= f.hidden_field :question_id %>
             </div>
             <div class="form-control mb-4">
               <%= f.label :title %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,8 +12,15 @@ ja:
         question_title: 対象問題
         title: 件名
         content: 詳細
+        question: 既存の問題タイトル
     enums:
       request:
         status:
           incompleted: 未完了
           completed: 完了
+    errors:
+      models:
+        request:
+          attributes:
+            question:
+              required: を入力してください

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -42,7 +42,6 @@ ja:
     new:
       title: 修正依頼を作成
       post: 投稿する
+      description: 問題タイトル（一部可）を入力 → 候補をクリックして選択してください。
     request_btn:
       request: 【準備中】修正依頼
-    question_search_form:
-      placeholder: 問題タイトルを入力して選択


### PR DESCRIPTION
## Issue
close: #146 #83 

# 概要
- 修正依頼の投稿機能を実装しました。
- 修正依頼投稿画面の問題選択（オートコンプリート）から、question.idをフォーム送信できるようにする設定を追加しました。
- request.rbで、各カラム空欄×、文字数（タイトル60字以内・詳細500字以内）のバリデーションを追加しました。
- 
# 備考・後でやること
-