### PR TITLE
fix: ログイン後のゲーム結果でクリック数が表示されなくなっていたため修正

### DIFF
--- a/app/controllers/game_records_controller.rb
+++ b/app/controllers/game_records_controller.rb
@@ -27,6 +27,8 @@ class GameRecordsController < ApplicationController
     if @latest_game_record
       # 保存されたゲーム記録のデータを使用
       @total_matches = @latest_game_record.total_matches
+      @total_clicks = session[:total_clicks] || 0
+      @correct_clicks = session[:correct_clicks] || 0
       @accuracy = @latest_game_record.accuracy
       @game_duration = @latest_game_record.completion_time_seconds
     else
@@ -43,15 +45,6 @@ class GameRecordsController < ApplicationController
 
     # 必要な組み合わせ数を計算
     @required_matches = session[:total_required_matches] || @question.card_sets.sum { |cs| cs.related_words.count }
-
-    # セッションクリア
-    session.delete(:game_question_id)
-    session.delete(:correct_matches)
-    session.delete(:total_required_matches)
-    session.delete(:game_start_time)
-    session.delete(:selected_origin_id)
-    session.delete(:total_clicks)
-    session.delete(:correct_clicks)
   end
 
   private

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,6 @@
 class GamesController < ApplicationController
   before_action :set_question, only: [ :show, :check_match ]
+  before_action :session_delete, only: [ :show ], if: :new_game_start?
 
   # GET /games/:id (questionのIDを使用)
   def show
@@ -174,5 +175,21 @@ class GamesController < ApplicationController
   def calculate_current_accuracy
     return 0 if session[:total_clicks].to_i == 0
     (session[:correct_clicks].to_f / session[:total_clicks] * 100).round(1)
+  end
+
+  def session_delete
+    # セッションクリア
+    session.delete(:game_question_id)
+    session.delete(:correct_matches)
+    session.delete(:total_required_matches)
+    session.delete(:game_start_time)
+    session.delete(:selected_origin_id)
+    session.delete(:total_clicks)
+    session.delete(:correct_clicks)
+  end
+
+  def new_game_start?
+    # 現在のゲームIDと異なる場合、または既存セッションがない場合は新ゲーム
+    session[:game_question_id] != @question.id
   end
 end


### PR DESCRIPTION
## 関連Issue
close済: #113 

## 関連Pr
#138

# 概要
- ログイン後のゲーム結果でクリック数が表示されなくなっていたため修正しました。
  - クリック数はDB保存されない状態ですが、ログイン時のゲーム結果画面はDBからのデータのみで表示していたことによる不具合でした。
  - クリック数は、ログイン時もセッション情報から取得するように修正しました。（引き続きDB保存はしない）
-  ログイン時もセッション情報からクリック数を取得するため、セッションクリアのタイミングをgamerecords#show（結果画面表示時）からgames#show（新しいゲーム開始）前のgames#session_delete実行時に変更しました。