### PR TITLE
add: 修正依頼詳細機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,16 +2,10 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :set_search
-  before_action :set_search_requests
 
   def set_search
     # @search = Question.search(params[:q])
     @search = Question.ransack(params[:q]) # ransackメソッド推奨
     @search_questions = @search.result(distinct: true).includes(:user, :tags).order(created_at: :desc).page(params[:page])
-  end
-
-  def set_search_requests
-    @search_request = Request.ransack(params[:q]) # ransackメソッド推奨
-    @search_requests = @search_request.result(distinct: true).includes(:user, :question).order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -2,6 +2,8 @@ class RequestsController < ApplicationController
   before_action :authenticate_user!, except: %i[ index ]
 
   def index
+    @search_request = Request.ransack(params[:q]) # ransackメソッド推奨
+    @search_requests = @search_request.result(distinct: true).includes(:user, :question, { question: :user }).order(created_at: :desc).page(params[:page])
     @current_requests_tab = params[:tab] || "requests"
   end
 
@@ -13,11 +15,15 @@ class RequestsController < ApplicationController
   def create
     @request = current_user.requests.build(request_params)
     if @request.save
-      redirect_to requests_path, success: t("defaults.flash_message.created", item: Request.model_name.human)
+      redirect_to request_path(@request), success: t("defaults.flash_message.created", item: Request.model_name.human)
     else
       flash.now[:danger] = t("defaults.flash_message.not_created", item: Request.model_name.human)
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @request = Request.find(params[:id])
   end
 
   private

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -1,25 +1,39 @@
 <%= paginate @search_requests, param_name: :requests_page, params: { tab: 'requests' } %>
 <% @search_requests.each do |request| %>
   <div id="request-id-<%= request.id %>">
-    <li class="list-row">
-      <div>
-        <div>
-          <%= link_to request.title, '#', class: "link" %>
-        </div>
-        <div class="text-xs font-semibold opacity-60">
-          <div>
-            <%= link_to request.question.title, question_path(request.question), class: "link" %>
+    <div class="p-2">
+      <ul class="list-inside bg-base-100 rounded-box shadow-md p-4">
+        <li class=" grid grid-cols-1 gap-4 m-2">
+          <div class="col-start-1 col-span-1">
+            <div class="flex items-center">
+              <div><%= render 'requests/status_badge', request: request %></div>
+              <%= link_to request.title, request_path(request), class: "link ml-2" %>
+            </div>
           </div>
-          <div class="lg:hidden pt-2" ><%= request.user.name %></div>
-        </div>
-        <div class="text-xs font-semibold opacity-60 pt-2 hidden lg:flex">
-          <div class="mr-2 "><%= request.user.name %></div>
-          <div><%= l request.created_at, format: :short %></div>
-        </div>
-      </div>
-        <div class="text-xs font-semibold opacity-60 pt-16 mr-2 text-right lg:hidden">
-          <div><%= l request.created_at, format: :short %></div>
-        </div>
-    </li>
+          <div class="col-start-1 col-span-1">
+            <div class="text-sm font-semibold opacity-60">
+              <div class="flex ">
+                <p class="min-w-max"><%= t('.question') %></p>
+                <p class="ml-2">
+                <%= link_to "#{request.question.title}  by #{request.question.user.name}", question_path(request.question), class: "link" %></p>
+              </div>
+              <div class="flex pt-2">
+                <p class="min-w-max"><%= t('.request_user') %></p>
+                <div class="ml-2" ><%= request.user.name %></div>
+              </div>
+            </div>
+          </div>
+          <div class="col-start-1 col-span-1">
+            <div class="text-sm font-semibold opacity-60">
+              <div class="flex justify-end">
+                <%= t('.created_at') %>
+                <%= l request.created_at, format: :short %>
+              </div>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
   </div>
 <% end %>
+

--- a/app/views/requests/_status_badge.html.erb
+++ b/app/views/requests/_status_badge.html.erb
@@ -1,0 +1,7 @@
+
+<% case request.status %>
+<% when 'incompleted' then %>
+  <div class="badge badge-warning"><%= t('.incompleted') %></div>
+<% when 'completed' then %>
+  <div class="badge badge-success"><%= t('.completed') %></div>
+<% end %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -18,14 +18,12 @@
                       class: 'tab',
                       aria: { label: t('.requests') } %>
     <div class="tab-content bg-base-100 border-base-300 p-6">
-      <ul class="list bg-base-100 rounded-box shadow-md">
           <!--%= render 'requests/requests' %-->
           <% if @search_requests.present? %>
             <%= render 'requests/request' %>
           <% else %>
-            <div class="m-8">履歴がありません</div>
+            <div class="m-8">この条件の依頼はありません</div>
           <% end %>
-      </ul>
     </div>
 
     <%= radio_button_tag 'my_tabs_3', 'requests_from_user', @current_requests_tab == 'requests_from_user',

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -2,6 +2,7 @@
   <div class="grid grid-cols-1 lg:grid-cols-8">
     <div class="lg:col-start-2 lg:col-span-6">
       <div class="card bg-base-100 shadow-lg p-6">
+      <%= link_to t('.to_index'), requests_path, class: "link" %>
         <div class="flex items-center pt-4">
           <div><%= render 'requests/status_badge', request: @request %></div>
           <h1 class="text-2xl font-bold text-left px-2"><%= @request.title %></h1>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -1,0 +1,36 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="grid grid-cols-1 lg:grid-cols-8">
+    <div class="lg:col-start-2 lg:col-span-6">
+      <div class="card bg-base-100 shadow-lg p-6">
+        <div class="flex items-center pt-4">
+          <div><%= render 'requests/status_badge', request: @request %></div>
+          <h1 class="text-2xl font-bold text-left px-2"><%= @request.title %></h1>
+        </div>
+        <div class="card-body">
+          <ul class="pl-2 text-sm">
+            <li class="pb-2"><%= t('.question') %><%= link_to @request.question.title, question_path(@request.question), class: "link" %></li>
+            <li><%= t('.request_user') %><%= @request.user.name %></li>
+            <li><%= t('.created_at') %><%= l @request.created_at, format: :long %></li>
+          </ul>
+          <h5 class="text-lg font-semibold pl-2 mt-6"><%= t('.content') %></h5>
+          <div class="pl-2">
+            <p><%= simple_format(@request.content) %></p>
+<%
+=begin%>
+返信機能つけ終わったら、修正依頼編集・削除機能つけるかも            
+          <div class="flex justify-end mt-4 space-x-4">
+            <%= link_to "#", id: "button-edit-#{@request.id}", class: "btn btn-ghost btn-sm" do %>
+              <i class="fa-solid fa-pen"></i>
+            <% end %>
+            <%= link_to "#", id: "button-delete-#{@request.id}", class: "btn btn-ghost btn-sm text-error" do %>
+              <i class="fa-solid fa-trash"></i>
+            <% end %>
+          </div>
+<%
+=end%>            
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -46,6 +46,7 @@ ja:
       post: 投稿する
       description: 問題タイトル（一部可）を入力 → 候補をクリックして選択してください。
     show:
+      to_index: "← 修正依頼一覧"
       content: 修正依頼内容
       request_responses: 対応履歴
       question: "対象問題: "

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,8 +20,6 @@ ja:
   questions:
     new:
       title: 問題作成
-    show:
-      title: 問題詳細
     index:
       title: 問題一覧
     edit:
@@ -39,9 +37,22 @@ ja:
       requests_to_user: 自分への依頼
       requests: みんなの依頼
       requests_from_user: 自分の依頼
+    request:
+      question: "対象問題: "
+      request_user: "投稿者　: "
+      created_at: "投稿日時: "
     new:
       title: 修正依頼を作成
       post: 投稿する
       description: 問題タイトル（一部可）を入力 → 候補をクリックして選択してください。
+    show:
+      content: 修正依頼内容
+      request_responses: 対応履歴
+      question: "対象問題: "
+      request_user: "投稿者　: "
+      created_at: "投稿日時: "
     request_btn:
       request: 【準備中】修正依頼
+    status_badge:
+      incompleted: 未完了
+      completed: 完了

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   end
 
   resources :game_records, only: %i[create show]
-  resources :requests, only: %i[index new create]
+  resources :requests, only: %i[index new create show]
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## Issue
close: #84 
## 概要
- 修正依頼詳細機能（requests#show）を実装しました。
#### 修正依頼詳細画面の記載項目
  - 完了ステータス（バッジ）
  - 対象問題タイトル
  - 依頼投稿者
  - 投稿日時
  - 修正依頼内容
  - 修正依頼一覧へのリンク
 #### 修正依頼詳細画面への導線
   - 修正依頼作成後→作成した修正依頼詳細画面に遷移
   - 修正依頼一覧で修正依頼件名を選択→選択した修正依頼詳細画面に遷移
## 備考・後でやること
- 修正依頼に対する返信機能は、 #112 で対応予定。