### PR TITLE
fix: Questionモデル・コントローラーに、タグ文字数制限のカスタムバリデーションを追加

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -23,6 +23,7 @@ class QuestionsController < ApplicationController
         tag_list = tag_json.split(",")
       end
     end
+    @question.tag_names = tag_list.join(",")
     if @question.save
       @question.save_tag(tag_list)
       # ステップ2（CardSet追加）にリダイレクト
@@ -58,6 +59,7 @@ class QuestionsController < ApplicationController
         tag_list = tag_json.split(",")
       end
     end
+    @question.tag_names = tag_list.join(",")
     if @question.update(question_params)
       @question.save_tag(tag_list)
       redirect_to question_path(@question), success: t("defaults.flash_message.updated", item: Question.model_name.human)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,6 +7,9 @@ class Question < ApplicationRecord
   validates :description, presence: true, length: { maximum: 150 }
   # validate :minimum_card_sets_required, on: :create
   validate :maximum_total_cards_limit
+  validate :validate_tag_names
+
+  attr_accessor :tag_names
 
   belongs_to :user
   has_many :game_records, dependent: :destroy
@@ -108,6 +111,18 @@ class Question < ApplicationRecord
   def maximum_total_cards_limit
     if total_cards_count > 10
       errors.add(:base, "カードの総数は10枚以内にしてください（現在：#{total_cards_count}枚）")
+    end
+  end
+
+  def validate_tag_names
+    return unless tag_names.present?
+
+    names = tag_names.split(",")
+
+    names.each do |name|
+      if name.length > 20
+        errors.add(:base, "タグは20文字以内で入力してください")
+      end
     end
   end
 


### PR DESCRIPTION
## 関連Issue
close済: #74

## 概要
- タグの20文字以内のバリデーションが正常に効いていない状態（タグは保存されないが、問題だけ保存されてしまう）だったため、 Questionモデル・コントローラーに、タグ文字数制限のカスタムバリデーションを追加しました。