### PR TITLE
add_修正依頼返信機能追加（修正依頼一覧微調整含む）

### DIFF
--- a/app/controllers/request_responses_controller.rb
+++ b/app/controllers/request_responses_controller.rb
@@ -1,10 +1,15 @@
 class RequestResponsesController < ApplicationController
   def create
-    request_response = current_user.request_responses.build(request_response_params)
-    if request_response.save
-      redirect_to request_path(request_response.request), notice: t("defaults.flash_message.sent", item: RequestResponse.model_name.human)
+    @request = Request.find(params[:request_id])
+    @request_response = current_user.request_responses.build(request_response_params)
+    @request_responses = @request.request_responses.includes(:user).order(created_at: :asc)
+    @latest_request_response = @request_responses.last
+    
+    if @request_response.save
+      redirect_to request_path(@request), notice: t("defaults.flash_message.sent", item: RequestResponse.model_name.human)
     else
-      redirect_to requests_path, alert: t("defaults.flash_message.not_sent", item: RequestResponse.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_sent", item: RequestResponse.model_name.human)
+      render 'requests/show', status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/request_responses_controller.rb
+++ b/app/controllers/request_responses_controller.rb
@@ -1,0 +1,16 @@
+class RequestResponsesController < ApplicationController
+  def create
+    request_response = current_user.request_responses.build(request_response_params)
+    if request_response.save
+      redirect_to request_path(request_response.request), notice: t("defaults.flash_message.sent", item: RequestResponse.model_name.human)
+    else
+      redirect_to requests_path, alert: t("defaults.flash_message.not_sent", item: RequestResponse.model_name.human)
+    end
+  end
+
+  private
+
+  def request_response_params
+    params.require(:request_response).permit(:content, :is_completed).merge(request_id: params[:request_id])
+  end
+end

--- a/app/controllers/request_responses_controller.rb
+++ b/app/controllers/request_responses_controller.rb
@@ -4,12 +4,12 @@ class RequestResponsesController < ApplicationController
     @request_response = current_user.request_responses.build(request_response_params)
     @request_responses = @request.request_responses.includes(:user).order(created_at: :asc)
     @latest_request_response = @request_responses.last
-    
+
     if @request_response.save
       redirect_to request_path(@request), notice: t("defaults.flash_message.sent", item: RequestResponse.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_sent", item: RequestResponse.model_name.human)
-      render 'requests/show', status: :unprocessable_entity
+      render "requests/show", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -11,7 +11,7 @@ class RequestsController < ApplicationController
     end
 
     @search_request = Request.ransack(search_params) # ransackメソッド推奨
-    @search_requests = @search_request.result(distinct: true).includes(:user, :question, { question: :user }).order(created_at: :desc).page(params[:page])
+    @search_requests = @search_request.result(distinct: true).includes(:user, :question, { question: :user }, { request_responses: :user }).order(created_at: :desc).page(params[:page])
     @current_requests_tab = params[:tab] || "requests"
   end
 
@@ -34,6 +34,7 @@ class RequestsController < ApplicationController
     @request = Request.find(params[:id])
     @request_response = RequestResponse.new
     @request_responses = @request.request_responses.includes(:user).order(created_at: :asc)
+    @latest_request_response = @request_responses.last
   end
 
   private

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -15,15 +15,17 @@ class RequestsController < ApplicationController
   def create
     @request = current_user.requests.build(request_params)
     if @request.save
-      redirect_to request_path(@request), success: t("defaults.flash_message.created", item: Request.model_name.human)
+      redirect_to request_path(@request), notice: t("defaults.flash_message.created", item: Request.model_name.human)
     else
-      flash.now[:danger] = t("defaults.flash_message.not_created", item: Request.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Request.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
 
   def show
     @request = Request.find(params[:id])
+    @request_response = RequestResponse.new
+    @request_responses = @request.request_responses.includes(:user).order(created_at: :desc)
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,4 +31,9 @@ module ApplicationHelper
    def turbo_stream_flash
     turbo_stream.update "flash", partial: "shared/flash_messages"
   end
+
+  def must_check_request_to_user_count
+    return 0 unless user_signed_in?
+    Request.joins(:question).where(questions: { user_id: current_user.id }, status: :incompleted).count
+  end
 end

--- a/app/models/request_response.rb
+++ b/app/models/request_response.rb
@@ -1,4 +1,25 @@
 class RequestResponse < ApplicationRecord
   belongs_to :request
   belongs_to :user
+
+  validates :content, presence: true, length: { maximum: 500 }
+  validates :is_completed, inclusion: { in: [true, false] }
+
+  validate :only_one_completed_response, if: :is_completed?
+
+  after_create :update_request_status_if_completed
+
+  private
+
+  def only_one_completed_response
+    if request.request_responses.where(is_completed: true).where.not(id: id).exists?
+      errors.add(:is_completed, "この依頼は完了しているため返信できません")
+    end
+  end
+
+  def update_request_status_if_completed
+    return unless is_completed?
+
+    request.update!(status: :completed)
+  end
 end

--- a/app/models/request_response.rb
+++ b/app/models/request_response.rb
@@ -1,0 +1,4 @@
+class RequestResponse < ApplicationRecord
+  belongs_to :request
+  belongs_to :user
+end

--- a/app/models/request_response.rb
+++ b/app/models/request_response.rb
@@ -3,19 +3,11 @@ class RequestResponse < ApplicationRecord
   belongs_to :user
 
   validates :content, presence: true, length: { maximum: 500 }
-  validates :is_completed, inclusion: { in: [true, false] }
-
-  validate :only_one_completed_response, if: :is_completed?
+  validates :is_completed, inclusion: { in: [ true, false ] }
 
   after_create :update_request_status_if_completed
 
   private
-
-  def only_one_completed_response
-    if request.request_responses.where(is_completed: true).where.not(id: id).exists?
-      errors.add(:is_completed, "この依頼は完了しているため返信できません")
-    end
-  end
 
   def update_request_status_if_completed
     return unless is_completed?

--- a/app/models/request_response.rb
+++ b/app/models/request_response.rb
@@ -3,7 +3,6 @@ class RequestResponse < ApplicationRecord
   belongs_to :user
 
   validates :content, presence: true, length: { maximum: 500 }
-  validates :is_completed, inclusion: { in: [ true, false ] }
 
   after_create :update_request_status_if_completed
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :questions, dependent: :destroy
   has_many :game_records, dependent: :destroy
   has_many :requests, dependent: :destroy
+  has_many :request_responses, dependent: :destroy
 
   def own?(object)
     id == object&.user_id

--- a/app/views/request_responses/_form.html.erb
+++ b/app/views/request_responses/_form.html.erb
@@ -1,0 +1,31 @@
+<div id="request_response-form" class="mb-6">
+  <div class="max-w-2xl mr-auto">
+    <%= form_with model: request_response, url: request_request_responses_path(request), class: "space-y-4" do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
+      <div>
+        <%= f.label :content, class: "label" do %>
+          <span class="label-text"><%= RequestResponse.human_attribute_name(:content) %></span>
+        <% end %>
+        <%= f.text_area :content, class: "textarea textarea-bordered w-full", rows: 4, placeholder: t('.placeholder') %>
+      </div>
+
+      <% if current_user.own?(request)||current_user.own?(request.question) %>
+        <div class="form-control">
+          <label class="cursor-pointer label">
+            <%= f.check_box :is_completed, class: "checkbox" %>
+            <span class="label-text ml-2"><%= t('.complete') %></span>
+          </label>
+          <div class="text-sm text-warning/80 ml-10 mt-[-2px] leading-tight">
+            <%= t('.no_more_response_attention') %>
+          </div>
+        </div>
+      <% else %>
+        <div class="text-sm label-text/60 ml-2 leading-tight">
+          <%= t('.who_can_complete') %>
+        </div>
+      <% end %>
+
+      <%= f.submit t('defaults.send'), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/request_responses/_request_response.html.erb
+++ b/app/views/request_responses/_request_response.html.erb
@@ -1,0 +1,17 @@
+<tr id="request_response-<%= request_response.id %>">
+  <div class="border-b border-current/50 border-dotted pb-4 mb-4">
+    <% if request_response.is_completed == true %>
+      <div class="badge badge-soft badge-success mb-2"><%= t('.completed') %></div>
+    <% end %>
+    <div class="px-6">
+      <td>
+        <h6 class="text-sm mt-0">
+          <div class="font-bold"><%= request_response.user.name %></div>
+          <div class="opacity-60"><%= l request_response.created_at, format: :long %></div>
+        </h6>
+        <p class="text-sm mt-2">
+          <%= simple_format(request_response.content) %>
+        </p>
+    </div>
+  </div>
+</tr>

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -9,22 +9,28 @@
               <div><%= render 'requests/status_badge', request: request %></div>
               <%= link_to request.title, request_path(request), class: "link ml-2" %>
             </div>
-          </div>
-          <div class="col-start-1 col-span-1">
-            <div class="text-sm font-semibold opacity-60">
-              <div class="flex ">
-                <p class="min-w-max"><%= t('.question') %></p>
-                <p class="ml-2">
-                <%= link_to "#{request.question.title}  by #{request.question.user.name}", question_path(request.question), class: "link" %></p>
-              </div>
-              <div class="flex pt-2">
+            <div class="text-sm">
+              <div class="flex ml-20">
                 <p class="min-w-max"><%= t('.request_user') %></p>
                 <div class="ml-2" ><%= request.user.name %></div>
               </div>
+                <p class="ml-20">
+                <%= link_to "#{request.question.title}  by #{request.question.user.name}", question_path(request.question), class: "link" %>
+                </p>
             </div>
           </div>
           <div class="col-start-1 col-span-1">
-            <div class="text-sm font-semibold opacity-60">
+            <div class="text-sm">
+              <% if request.request_responses.present? %>
+                <div class="flex pt-2">
+                  <p class="min-w-max"><%= t('.last_response_user') %></p>
+                  <div class="ml-2"><%= request.request_responses.last.user.name %></div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <div class="col-start-1 col-span-1">
+            <div class="text-sm">
               <div class="flex justify-end">
                 <%= t('.created_at') %>
                 <%= l request.created_at, format: :short %>
@@ -36,4 +42,3 @@
     </div>
   </div>
 <% end %>
-

--- a/app/views/requests/_request.html.erb
+++ b/app/views/requests/_request.html.erb
@@ -1,44 +1,64 @@
-<%= paginate @search_requests, param_name: :requests_page, params: { tab: 'requests' } %>
-<% @search_requests.each do |request| %>
-  <div id="request-id-<%= request.id %>">
-    <div class="p-2">
-      <ul class="list-inside bg-base-100 rounded-box shadow-md p-4">
-        <li class=" grid grid-cols-1 gap-4 m-2">
-          <div class="col-start-1 col-span-1">
-            <div class="flex items-center">
-              <div><%= render 'requests/status_badge', request: request %></div>
-              <%= link_to request.title, request_path(request), class: "link ml-2" %>
-            </div>
-            <div class="text-sm">
-              <div class="flex ml-20">
-                <p class="min-w-max"><%= t('.request_user') %></p>
-                <div class="ml-2" ><%= request.user.name %></div>
+<%
+  tab_type = local_assigns[:tab_type]
+  
+  # タブに応じてフィルタリングした修正依頼を取得
+  filtered_requests = @search_requests.select do |request|
+    case tab_type
+    when 'requests_to_user'
+      request.question.user == current_user
+    when 'requests_from_user'
+      request.user == current_user
+    else # 'requests'
+      true
+    end
+  end
+%>
+
+<% if filtered_requests.present? %>
+  <%= paginate @search_requests, param_name: :requests_page, params: { tab: 'requests' } %>
+  <% filtered_requests.each do |request| %>
+    <div id="request-id-<%= request.id %>">
+      <div class="p-2">
+        <ul class="list-inside bg-base-100 rounded-box shadow-md p-4">
+          <li class=" grid grid-cols-1 gap-4 m-2">
+            <div class="col-start-1 col-span-1">
+              <div class="flex items-center">
+                <div><%= render 'requests/status_badge', request: request %></div>
+                <%= link_to request.title, request_path(request), class: "link ml-2" %>
               </div>
-                <p class="ml-20">
-                <%= link_to "#{request.question.title}  by #{request.question.user.name}", question_path(request.question), class: "link" %>
-                </p>
-            </div>
-          </div>
-          <div class="col-start-1 col-span-1">
-            <div class="text-sm">
-              <% if request.request_responses.present? %>
-                <div class="flex pt-2">
-                  <p class="min-w-max"><%= t('.last_response_user') %></p>
-                  <div class="ml-2"><%= request.request_responses.last.user.name %></div>
+              <div class="text-sm">
+                <div class="flex ml-20">
+                  <p class="min-w-max"><%= t('.request_user') %></p>
+                  <div class="ml-2" ><%= request.user.name %></div>
                 </div>
-              <% end %>
-            </div>
-          </div>
-          <div class="col-start-1 col-span-1">
-            <div class="text-sm">
-              <div class="flex justify-end">
-                <%= t('.created_at') %>
-                <%= l request.created_at, format: :short %>
+                  <p class="ml-20">
+                  <%= link_to "#{request.question.title}  by #{request.question.user.name}", question_path(request.question), class: "link" %>
+                  </p>
               </div>
             </div>
-          </div>
-        </li>
-      </ul>
+            <div class="col-start-1 col-span-1">
+              <div class="text-sm">
+                <% if request.request_responses.present? %>
+                  <div class="flex pt-2">
+                    <p class="min-w-max"><%= t('.last_response_user') %></p>
+                    <div class="ml-2"><%= request.request_responses.last.user.name %></div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+            <div class="col-start-1 col-span-1">
+              <div class="text-sm">
+                <div class="flex justify-end">
+                  <%= t('.created_at') %>
+                  <%= l request.created_at, format: :short %>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
+  <% end %>
+<% else %>
+  <div class="m-8"><%= t('requests.index.requests_empty') %></div>
 <% end %>

--- a/app/views/requests/_request_btn.html.erb
+++ b/app/views/requests/_request_btn.html.erb
@@ -1,1 +1,1 @@
-<%= link_to t('.request'), '#', class: "btn btn-accent w-full sm:w-auto" %>
+<%= link_to t('.request'), new_request_path, class: "btn btn-accent w-full sm:w-auto" %>

--- a/app/views/requests/_search_form.html.erb
+++ b/app/views/requests/_search_form.html.erb
@@ -9,26 +9,26 @@
               <path d="m21 21-4.3-4.3"></path>
             </g>
           </svg>
-          <%= f.search_field :title_or_question_title_or_content_or_user_name_cont, placeholder: 'キーワードで検索', class: "sm:w-64 md:w-64" %>
+          <%= f.search_field :title_or_question_title_or_content_or_user_name_cont, placeholder: t('.placeholder'), class: "sm:w-64 md:w-64" %>
         </label>
-          <div class="flex gap-4 mt-2">
-            <% Request.statuses.each do |key, value| %>
-              <% 
-                # デフォルトは未完了のみ選択、検索後は検索条件を保持
-                checked = if params[:q] && params[:q][:status_in]
-                           params[:q][:status_in].include?(value.to_s)
-                         else
-                           key == 'incompleted'
-                         end
-              %>
-              <%= check_box_tag "q[status_in][]", value, checked, class: "checkbox", id: "status_#{key}" %>
-              <label for="status_<%= key %>" class="text-base">
-                <%= t("activerecord.enums.request.status.#{key}") %>
-              </label>
-            <% end %>
-          </div>
+        <div class="flex gap-4 mt-2">
+          <% Request.statuses.each do |key, value| %>
+            <% 
+              # デフォルトは未完了のみ選択、検索後は検索条件を保持
+              checked = if params[:q] && params[:q][:status_in]
+                          params[:q][:status_in].include?(value.to_s)
+                        else
+                          key == 'incompleted'
+                        end
+            %>
+            <%= check_box_tag "q[status_in][]", value, checked, class: "checkbox", id: "status_#{key}" %>
+            <label for="status_<%= key %>" class="text-base">
+              <%= t("activerecord.enums.request.status.#{key}") %>
+            </label>
+          <% end %>
+        </div>
         <div class="justify-end card-actions">
-          <%= f.submit "検索", class: "btn btn-accent mt-2" %>
+          <%= f.submit t('defaults.search'), class: "btn btn-outline mt-2" %>
         </div>
       </div>
     <% end %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -4,6 +4,9 @@
     <%= render 'search_form' %>
   </div>
 </div>
+<div class="p-6">
+  <%= render 'requests/request_btn' %>
+</div>
 
 <% if user_signed_in? %>
   <div class="tabs tabs-lift mt-3 p-4">
@@ -18,12 +21,12 @@
                       class: 'tab',
                       aria: { label: t('.requests') } %>
     <div class="tab-content bg-base-100 border-base-300 p-6">
-          <!--%= render 'requests/requests' %-->
-          <% if @search_requests.present? %>
-            <%= render 'requests/request' %>
-          <% else %>
-            <div class="m-8">この条件の依頼はありません</div>
-          <% end %>
+      <!--%= render 'requests/requests' %-->
+      <% if @search_requests.present? %>
+        <%= render 'requests/request' %>
+      <% else %>
+        <div class="m-8"><%= t('.requests_empty') %></div>
+      <% end %>
     </div>
 
     <%= radio_button_tag 'my_tabs_3', 'requests_from_user', @current_requests_tab == 'requests_from_user',
@@ -36,12 +39,11 @@
 <% else %>
   <div class="p-3">
     <ul class="list bg-base-100 rounded-box shadow-md">
-        <!--%= render 'requests/requests' %-->
-        <% if @search_requests.present? %>
-          <%= render 'requests/request' %>
-        <% else %>
-          <div class="m-8">履歴がありません</div>
-        <% end %>
+      <% if @search_requests.present? %>
+        <%= render 'requests/request' %>
+      <% else %>
+        <div class="m-8"><%= t('.requests_empty' )%></div>
+      <% end %>
     </ul>
   </div>
 <% end %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -14,7 +14,11 @@
                       class: 'tab',
                       aria: { label: t('.requests_to_user') } %>
     <div class="tab-content bg-base-100 border-base-300 p-6">
-      準備中！気長にお待ちください🙇‍♀️
+      <% if @search_requests.present? %>
+        <%= render 'requests/request', tab_type: 'requests_to_user' %>
+      <% else %>
+        <div class="m-8"><%= t('.requests_empty') %></div>
+      <% end %>
     </div>
 
     <%= radio_button_tag 'my_tabs_3', 'requests', @current_requests_tab == 'requests',
@@ -23,7 +27,7 @@
     <div class="tab-content bg-base-100 border-base-300 p-6">
       <!--%= render 'requests/requests' %-->
       <% if @search_requests.present? %>
-        <%= render 'requests/request' %>
+        <%= render 'requests/request', tab_type: 'requests' %>
       <% else %>
         <div class="m-8"><%= t('.requests_empty') %></div>
       <% end %>
@@ -33,14 +37,18 @@
                       class: 'tab',
                       aria: { label: t('.requests_from_user') } %>
     <div class="tab-content bg-base-100 border-base-300 p-6">
-      準備中！気長にお待ちください🙇‍♀️
+      <% if @search_requests.present? %>
+        <%= render 'requests/request', tab_type: 'requests_from_user' %>
+      <% else %>
+        <div class="m-8"><%= t('.requests_empty') %></div>
+      <% end %>
     </div>
   </div>
 <% else %>
   <div class="p-3">
     <ul class="list bg-base-100 rounded-box shadow-md">
       <% if @search_requests.present? %>
-        <%= render 'requests/request' %>
+        <%= render 'requests/request', tab_type: 'requests' %>
       <% else %>
         <div class="m-8"><%= t('.requests_empty' )%></div>
       <% end %>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -9,28 +9,37 @@
         </div>
         <div class="card-body">
           <ul class="pl-2 text-sm">
-            <li class="pb-2"><%= t('.question') %><%= link_to @request.question.title, question_path(@request.question), class: "link" %></li>
+
+            
+
+            <li class="pb-2"><%= t('.question') %><%= link_to "#{@request.question.title}  by #{@request.question.user.name}", question_path(@request.question), class: "link" %></li>
             <li><%= t('.request_user') %><%= @request.user.name %></li>
-            <li><%= t('.created_at') %><%= l @request.created_at, format: :long %></li>
+            <li class="pb-2"><%= t('.created_at') %><%= l @request.created_at, format: :long %></li>
+            <% if @latest_request_response %>
+              <li><%= t('.last_response_user') %><%= @latest_request_response.user.name %></li>
+              <li><%= t('.last_response_created_at') %><%= l @latest_request_response.created_at, format: :long %></li>
+            <% end %>
           </ul>
-          <h5 class="text-lg font-semibold pl-2 mt-6"><%= t('.content') %></h5>
-          <div class="pl-2">
-            <p><%= simple_format(@request.content) %></p>
-<%
-=begin%>
-返信機能つけ終わったら、修正依頼編集・削除機能つけるかも            
-          <div class="flex justify-end mt-4 space-x-4">
-            <%= link_to "#", id: "button-edit-#{@request.id}", class: "btn btn-ghost btn-sm" do %>
-              <i class="fa-solid fa-pen"></i>
-            <% end %>
-            <%= link_to "#", id: "button-delete-#{@request.id}", class: "btn btn-ghost btn-sm text-error" do %>
-              <i class="fa-solid fa-trash"></i>
-            <% end %>
-          </div>
-<%
-=end%>            
-          </div>
         </div>
+          <h5 class="text-lg font-semibold pl-6"><%= t('.content') %></h5>
+          <div class="pl-6">
+            <p><%= simple_format(@request.content) %></p>
+          </div>
+          <h5 class="text-lg font-semibold pl-6 mt-6"><%= t('.responses') %></h5>
+          <div class="pl-2">
+            <%= render @request_responses %>
+              <% if @request.status != "completed" %>
+                <% if user_signed_in? %>
+                 <%= render 'request_responses/form', request_response: @request_response, request: @request %>
+                <% else %>
+                  <span class="label-text ml-2"><%= t('.require_login') %></span>
+                <% end %>
+              <% else %>
+                <div class="request-response-closed-message bg-accent">
+                  <%= t('.closed') %>
+                </div>
+              <% end %>
+          </div>
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -61,39 +61,47 @@
       </ul>
     </div>
     <!-- PC版ユーザーメニュー -->
-    <div class="navbar-end dropdown dropdown-end hidden lg:flex">
-      <ul class="menu menu-horizontal px-1">
-        <li>
-        <details>
-          <summary class="text-xl">
-            <%= turbo_frame_tag "header_name_pc" do %>
-              <%= render "shared/header_name" %>
-            <% end %>
-          </summary>
-          <ul class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" >
-            <li><a>準備中</a></li>
-            <li><a>準備中</a>
-              <ul class="p-2">
-                <li><a>準備中</a></li>
-                <li><a>準備中</a></li>
-              </ul>
-            </li>
-            <li><%= link_to 'お問い合わせ', 'https://x.com/MO_study2408' %></li>
-            <li>
-              <%= link_to destroy_user_session_path, class: "text-warning", data: { turbo_method: :delete } do %>
-                <i class="fa-solid fa-right-from-bracket" viewBox="0 0 24 24"></i>
-                <span>ログアウト</span>
+    <div class="navbar-end hidden lg:flex">
+        <% if must_check_request_to_user_count > 0 %>
+          <%= link_to requests_path(tab: 'requests_to_user'), class: "btn btn-warning" do %>
+            <i class="fa-solid fa-hand-pointer fa-rotate-90 pr-2" viewBox="0 0 24 24"></i>
+            <%= t('.requests_to_user') %>
+          <% end %>
+        <% end %>
+      <div class="dropdown dropdown-end">
+        <ul class="menu menu-horizontal px-1">
+          <li>
+          <details>
+            <summary class="text-xl">
+              <%= turbo_frame_tag "header_name_pc" do %>
+                <%= render "shared/header_name" %>
               <% end %>
-            </li>
-            <li></li>
-            <li></li>
-            <li><div div class='copyright'>
-              <p>Copyright © 2025 NeuroWord～仲間の言葉を見つけよう！～</p>
-            </div></li>
-          </ul>
-        </details>
-        </li>
-      </ul>
+            </summary>
+            <ul class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm" >
+              <li><a>準備中</a></li>
+              <li><a>準備中</a>
+                <ul class="p-2">
+                  <li><a>準備中</a></li>
+                  <li><a>準備中</a></li>
+                </ul>
+              </li>
+              <li><%= link_to 'お問い合わせ', 'https://x.com/MO_study2408' %></li>
+              <li>
+                <%= link_to destroy_user_session_path, class: "text-warning", data: { turbo_method: :delete } do %>
+                  <i class="fa-solid fa-right-from-bracket" viewBox="0 0 24 24"></i>
+                  <span>ログアウト</span>
+                <% end %>
+              </li>
+              <li></li>
+              <li></li>
+              <li><div div class='copyright'>
+                <p>Copyright © 2025 NeuroWord～仲間の言葉を見つけよう！～</p>
+              </div></li>
+            </ul>
+          </details>
+          </li>
+        </ul>
+      </div>
     </div>
   <% else %>
     <!-- 共通_ログイン前メニュー -->

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -4,6 +4,7 @@ ja:
       user: ユーザー
       question: 問題
       request: 修正依頼
+      request_response: 返信
     attributes:
       question:
         title: タイトル
@@ -13,6 +14,8 @@ ja:
         title: 件名
         content: 詳細
         question: 既存の問題タイトル
+      request_response:
+        content: 修正依頼に返信
     enums:
       request:
         status:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -48,7 +48,6 @@ ja:
       requests_from_user: 自分の依頼
       requests_empty: この条件の依頼はありません
     request:
-      question: "対象問題　: "
       request_user: "by "
       last_response_user: "最終返信者: "
       created_at: "依頼投稿日時: "

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -2,11 +2,15 @@ ja:
   defaults:
     create: 作成
     post: 投稿
+    send: 送信
     edit: 編集
+    search: 検索
     delete_confirm: 削除しますか？
     flash_message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成出来ませんでした"
+      sent: "%{item}を送信しました"
+      not_sent: "%{item}を送信出来ませんでした"
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
@@ -32,11 +36,14 @@ ja:
       user_lists: リスト
       game_records: プレイ履歴
   requests:
+    search_form:
+      placeholder: キーワードで検索
     index:
       title: 修正依頼一覧
       requests_to_user: 自分への依頼
       requests: みんなの依頼
       requests_from_user: 自分の依頼
+      requests_empty: この条件の依頼はありません
     request:
       question: "対象問題: "
       request_user: "投稿者　: "
@@ -48,12 +55,27 @@ ja:
     show:
       to_index: "← 修正依頼一覧"
       content: 修正依頼内容
-      request_responses: 対応履歴
+      responses: 対応履歴
+      require_login: 修正履歴に返信する場合は、ログインしてください
       question: "対象問題: "
       request_user: "投稿者　: "
       created_at: "投稿日時: "
     request_btn:
-      request: 【準備中】修正依頼
+      request: 修正依頼を投稿する
     status_badge:
       incompleted: 未完了
       completed: 完了
+  request_responses:
+    form:
+      placeholder: |
+                    〈例1：問題作成者〉
+                    　　修正対応が完了しました。ご報告いただき、ありがとうございました！
+                    〈例2：他〉
+                    　　補足です。～～。よろしくお願いします。
+
+      complete: この返信で修正対応を完了する
+      no_more_response_attention:  ※完了後は、返信不可となります
+      who_can_complete: ※ 修正依頼完了チェック欄は、問題作成者・依頼投稿者のみに表示されます。
+    request_response:
+      created_at: "返信日時: "
+      completed: この返信で完了しました

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -45,9 +45,10 @@ ja:
       requests_from_user: 自分の依頼
       requests_empty: この条件の依頼はありません
     request:
-      question: "対象問題: "
-      request_user: "投稿者　: "
-      created_at: "投稿日時: "
+      question: "対象問題　: "
+      request_user: "by "
+      last_response_user: "最終返信者: "
+      created_at: "依頼投稿日時: "
     new:
       title: 修正依頼を作成
       post: 投稿する
@@ -57,14 +58,17 @@ ja:
       content: 修正依頼内容
       responses: 対応履歴
       require_login: 修正履歴に返信する場合は、ログインしてください
-      question: "対象問題: "
-      request_user: "投稿者　: "
-      created_at: "投稿日時: "
+      question: "対象問題　　: "
+      request_user: "投稿者　　　: "
+      last_response_user: "最終返信者　: "
+      last_response_created_at: "最終返信日時: "
+      created_at: "投稿日時　　: "
+      closed: この修正依頼はクローズしました。新しい修正依頼を投稿してください。
     request_btn:
       request: 修正依頼を投稿する
     status_badge:
       incompleted: 未完了
-      completed: 完了
+      completed: " 完了 "
   request_responses:
     form:
       placeholder: |

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -15,6 +15,9 @@ ja:
       not_updated: "%{item}を更新出来ませんでした"
       deleted: "%{item}を削除しました"
       require_login: ログインしてください
+  shared:
+    header:
+      requests_to_user: 修正依頼が届きました！要チェック！
   pagination:
     first: 最初
     last: 最後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,9 @@ Rails.application.routes.draw do
   end
 
   resources :game_records, only: %i[create show]
-  resources :requests, only: %i[index new create show]
+  resources :requests, only: %i[index new create show] do
+    resources :request_responses, only: %i[create], shallow: true
+  end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250907081808_create_request_responses.rb
+++ b/db/migrate/20250907081808_create_request_responses.rb
@@ -1,0 +1,12 @@
+class CreateRequestResponses < ActiveRecord::Migration[7.2]
+  def change
+    create_table :request_responses do |t|
+      t.references :request, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :content, null: false
+      t.boolean :is_completed
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_03_143946) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_07_081808) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,7 +44,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_03_143946) do
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["question_id", "tag_id"], name: "index_question_tags_on_question_id_and_tag_id", unique: true
     t.index ["question_id"], name: "index_question_tags_on_question_id"
     t.index ["tag_id"], name: "index_question_tags_on_tag_id"
   end
@@ -57,6 +56,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_03_143946) do
     t.datetime "updated_at", null: false
     t.index ["title"], name: "index_questions_on_title", unique: true
     t.index ["user_id"], name: "index_questions_on_user_id"
+  end
+
+  create_table "request_responses", force: :cascade do |t|
+    t.bigint "request_id", null: false
+    t.bigint "user_id", null: false
+    t.text "content", null: false
+    t.boolean "is_completed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["request_id"], name: "index_request_responses_on_request_id"
+    t.index ["user_id"], name: "index_request_responses_on_user_id"
   end
 
   create_table "requests", force: :cascade do |t|
@@ -97,6 +107,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_03_143946) do
   add_foreign_key "question_tags", "questions"
   add_foreign_key "question_tags", "tags"
   add_foreign_key "questions", "users"
+  add_foreign_key "request_responses", "requests"
+  add_foreign_key "request_responses", "users"
   add_foreign_key "requests", "questions"
   add_foreign_key "requests", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_07_081808) do
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["question_id", "tag_id"], name: "index_question_tags_on_question_id_and_tag_id", unique: true
     t.index ["question_id"], name: "index_question_tags_on_question_id"
     t.index ["tag_id"], name: "index_question_tags_on_tag_id"
   end

--- a/test/fixtures/request_responses.yml
+++ b/test/fixtures/request_responses.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  request: one
+  user: one
+  content: MyText
+  is_completed: false
+
+two:
+  request: two
+  user: two
+  content: MyText
+  is_completed: false

--- a/test/models/request_response_test.rb
+++ b/test/models/request_response_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RequestResponseTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Issue
close: #112

## 概要
- 修正依頼に対する返信機能を追加しました。
- 修正依頼を完了できるようにしました。
- 修正依頼一覧画面に、返信に関する項目を追加しました。

また、以下機能も追加しています。
- 修正依頼一覧で、タブごとの絞り込み指定を追加しました。
- 自分宛の修正依頼が届いた場合、ヘッダーに通知ボタンを表示できるようにしました。

本来はこれらのブランチを分けるべきでしたが、自分宛の修正依頼がわかる方法はなるはやで用意すべきと考え、
このような形での追加となりました。
（とはいえ、なるはやで実装するにしてもブランチの分けようはあったはずなので、今後は気を付けます。）

## 修正依頼詳細画面
#### ログイン時
※ログインユーザーが依頼・問題作成ではない場合、完了チェックボタンは表示されません。
|未完了|完了済|
|---|---|
|[![Image from Gyazo](https://i.gyazo.com/237168183c0b5ddb34a326b801260ae7.png)](https://gyazo.com/237168183c0b5ddb34a326b801260ae7)|[![Image from Gyazo](https://i.gyazo.com/f2d60ad51d3f6ffdddbfebb046597e32.png)](https://gyazo.com/f2d60ad51d3f6ffdddbfebb046597e32)|
#### 未ログイン時
|未完了|完了済|
|---|---|
|[![Image from Gyazo](https://i.gyazo.com/eb4a10bac36868398f0c160d56daefc8.png)](https://gyazo.com/eb4a10bac36868398f0c160d56daefc8)|ログイン時と同じ|

## 修正依頼一覧画面
#### ログイン時
|返信なし|返信あり|
|----|------|
|[![Image from Gyazo](https://i.gyazo.com/bbfb1eee6804e6f5fe7a56cfd9e9571c.png)](https://gyazo.com/bbfb1eee6804e6f5fe7a56cfd9e9571c)|[![Image from Gyazo](https://i.gyazo.com/abd45d235e2cd684a7018909ab39eed6.png)](https://gyazo.com/abd45d235e2cd684a7018909ab39eed6)|

## ヘッダー
※PCでログイン済かつ、自分が作成した問題への修正依頼（未完了）がある場合のみ
[![Image from Gyazo](https://i.gyazo.com/2664c878ebea7b7a7eea2803fc534a84.png)](https://gyazo.com/2664c878ebea7b7a7eea2803fc534a84)

## 追加・変更記載項目
### 修正依頼詳細画面（追加のみ）
- [x] 見出し「対応履歴」
- 返信がある場合のみ
  - [x] 最終返信者
  - [x] 最終返信日時
- 返信フォーム
  - ログイン時
    - [x] 返信文面入力欄
    - [x] 修正完了チェック欄（問題作成者・依頼投稿者のみ表示）
    - [x] 注釈「完了後は、返信不可となります」
    - [x] 返信送信ボタン
    - [x] ※修正完了時のみフォーム代わりに表示：「この修正依頼はクローズしました。新しい修正依頼を投稿してください。」
  - 未ログイン時
     - [x] 注釈：修正履歴に返信する場合は、ログインしてください

- 返信一覧
  - [x] 返信者
  - [x] 返信日時
  - [x] 返信文面
  - [x] ※修正完了チェックが付いた返信のみに表示：「この返信で完了しました」バナー

### 修正依頼一覧画面
  - 追加
  - [x] 最終返信者（返信がある場合のみ）
  - 変更
  - [x] 依頼作成者（項目名・レイアウト変更）
  - [x] 問題名（項目名削除）
  - [x] 依頼投稿日時（項目名変更）

### ヘッダー（追加のみ）
※PCでログイン済かつ、自分が作成した問題への修正依頼（未完了）がある場合のみ
- [x] 修正依頼が届きました！ボタン → 「自分への修正依頼」タブへ遷移

## 備考・後でやること
- 今回対応しきれていない導線追加は、 #85 で対応予定。