### PR TITLE
fix: flash and error messages

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -30,7 +30,7 @@ class QuestionsController < ApplicationController
       redirect_to new_question_card_set_path(@question),
                   notice: "ステップ1完了！カードセットを追加してください（2組以上）"
     else
-      flash.now[:danger] = t("defaults.flash_message.not_created", item: Question.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Question.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -62,9 +62,9 @@ class QuestionsController < ApplicationController
     @question.tag_names = tag_list.join(",")
     if @question.update(question_params)
       @question.save_tag(tag_list)
-      redirect_to question_path(@question), success: t("defaults.flash_message.updated", item: Question.model_name.human)
+      redirect_to question_path(@question), notice: t("defaults.flash_message.updated", item: Question.model_name.human)
     else
-      flash.now[:danger] = t("defaults.flash_message.not_updated", item: Question.model_name.human)
+      flash.now[:alert] = t("defaults.flash_message.not_updated", item: Question.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end
@@ -72,7 +72,7 @@ class QuestionsController < ApplicationController
   def destroy
   question = current_user.questions.find(params[:id])
     question.destroy!
-    redirect_to questions_path, success: t("defaults.flash_message.deleted", item: Question.model_name.human), status: :see_other
+    redirect_to questions_path, notice: t("defaults.flash_message.deleted", item: Question.model_name.human), status: :see_other
   end
 
   def search_tag

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if object.errors.any? %>
-  <div id="error_explanation" class="alert alert-error shadow-lg mb-4">
+  <div id="error_explanation" class="bg-yellow-200 backdrop-opacity-5 text-red-600 text-bold mb-4 p-2 rounded-md">
     <ul class="list-disc list-inside">
       <% object.errors.each do |error| %>
         <li><%= error.full_message %></li>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -16,6 +16,9 @@ ja:
         question: 既存の問題タイトル
       request_response:
         content: 修正依頼に返信
+      card_set:
+        origin_word: 起点単語
+        related_words: 関連語
     enums:
       request:
         status:


### PR DESCRIPTION
## 概要
- フラッシュメッセージの出し方を修正しました。
  - app/controllers/questions_controller.rbで、app/views/shared/_flash_messages.html.erb で定義されていないタイプが使われていたため、_flash_messages.html.erb に合わせたタイプを使うように修正しました。
- バリデーションエラーの配色（赤背景/赤文字）が、エラー時のフラッシュメッセージの配色と同じで圧が強かったため、少し柔らかめの配色（柔らかい黄背景/赤文字）に変更しました。
- カードセットのバリデーションエラーで一部日本語化が不十分だったため、修正しました。