### PR TITLE
fix: スマホのヘッダー・dock関連修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,9 @@
     <div id="flash" class="relative z-1">
       <%= render 'shared/flash_messages' %>
     </div>
-    <%= yield %>
+    <div class="mb-28 lg:mb-0">
+      <%= yield %>
+    </div>
     <div class="hidden lg:flex">
       <%= render 'shared/footer' %>
     </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,7 +1,7 @@
-<div class="bg-base-200">
+<div class="p-2">
   <%= render 'search_form' %>
   <%= paginate @search_questions %>
-  <div class="bg-base-200 grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-12 mx-auto max-w-screen-6xl py-8 items-stretch">
+  <div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-12 mx-auto max-w-screen-6xl py-8 items-stretch">
   <!-- 問題一覧 -->
     <% if @search_questions.present? %>
       <%= render @search_questions %>

--- a/app/views/shared/_header_end_authenticated.html.erb
+++ b/app/views/shared/_header_end_authenticated.html.erb
@@ -5,13 +5,8 @@
               <%= render 'shared/request_to_user_btn' %>
             </li>
           <% end %>
-          <li class="lg:hidden"><a><%= t('shared.defaults.mypage') %></a>
+          <li class="lg:hidden"><a><%= link_to t('shared.defaults.mypage'), mypage_user_path %></a>
             <ul class="p-2">
-              <li>
-                <%= link_to mypage_user_path do %>
-                  <span class="whitespace-nowrap">TOP</span>
-                <% end %>
-              </li>
               <li>
                 <%= link_to mypage_user_path(tab: 'user_questions') do %>
                   <span class="whitespace-nowrap"><%= t('shared.defaults.user_questions') %></span>


### PR DESCRIPTION
## Issue
close済: #132

## 概要
- スマホ画面でdock分のbody余白が足りずに表示が切れてしまっていたため、修正しました。
- 上記に伴い、問題一覧の背景色を変更しました。
- スマホのヘッダーメニューを、以下の通り修正しました。
  - 「マイページ（見出し/リンクなし）」→「マイページ（見出し/マイページにリンク）」
  - 「TOP（マイページにリンク）」→削除

