### PR TITLE
fix: coverageをgit追跡しない設定が誤っていたため修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@
 .DS_Store
 /vendor/bundle
 
-echo coverage >> .gitignore
+coverage


### PR DESCRIPTION
## Issue
close: #171

## 概要
- coverageをgit追跡しないための設定が誤っていたため、修正しました。
