### PR TITLE
fix: coverageディレクトリの追跡除外設定を再修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@
 .DS_Store
 /vendor/bundle
 
-# coverage/
+coverage/


### PR DESCRIPTION
## 概要
- coverageディレクトリの追跡除外を再設定しました。
（GitHub上からcoverageディレクトリを削除するにあたって、一時的に除外解除していました。）