### PR TITLE
add: origin_cards・related_cardsテーブルを追加

### DIFF
--- a/app/models/origin_word.rb
+++ b/app/models/origin_word.rb
@@ -1,3 +1,6 @@
 class OriginWord < ApplicationRecord
   belongs_to :question
+  has_many :related_words, dependent: :destroy
+
+  validates :origin_word, presence: true, length: { maximum: 50 }
 end

--- a/app/models/origin_word.rb
+++ b/app/models/origin_word.rb
@@ -1,0 +1,3 @@
+class OriginWord < ApplicationRecord
+  belongs_to :question
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,6 @@
 class Question < ApplicationRecord
   has_many :card_sets, dependent: :destroy
+  has_many :origin_words, dependent: :destroy
   has_many :question_tags, dependent: :destroy
   has_many :tags, through: :question_tags
 

--- a/app/models/related_word.rb
+++ b/app/models/related_word.rb
@@ -1,0 +1,3 @@
+class RelatedWord < ApplicationRecord
+  belongs_to :origin_word
+end

--- a/app/models/related_word.rb
+++ b/app/models/related_word.rb
@@ -1,3 +1,23 @@
 class RelatedWord < ApplicationRecord
   belongs_to :origin_word
+
+  validates :related_word, uniqueness: { scope: :origin_word_id }
+  validate :uniqueness_within_question
+
+  private
+
+  def uniqueness_within_question
+    return unless origin_word&.question
+
+    # 同じ問題内の他のorigin_wordに紐づくrelated_wordsと重複チェック
+    question = origin_word.question
+    existing_related_words = RelatedWord.joins(:origin_word)
+                                        .where(origin_words: { question_id: question.id })
+                                        .where(related_word: related_word)
+                                        .where.not(id: id) # 自分自身は除外
+
+    if existing_related_words.exists?
+      errors.add(:related_word, "は既にこの問題内で使用されています")
+    end
+  end
 end

--- a/db/migrate/20251005024933_create_origin_words.rb
+++ b/db/migrate/20251005024933_create_origin_words.rb
@@ -1,0 +1,10 @@
+class CreateOriginWords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :origin_words do |t|
+      t.references :question, null: false, foreign_key: true
+      t.string :origin_word, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251005024949_create_related_words.rb
+++ b/db/migrate/20251005024949_create_related_words.rb
@@ -1,0 +1,11 @@
+class CreateRelatedWords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :related_words do |t|
+      t.references :origin_word, null: false, foreign_key: true
+      t.string :related_word, null: false
+
+      t.timestamps
+    end
+    add_index :related_words, [:origin_word_id, :related_word], unique: true
+  end
+end

--- a/db/migrate/20251005024949_create_related_words.rb
+++ b/db/migrate/20251005024949_create_related_words.rb
@@ -6,6 +6,6 @@ class CreateRelatedWords < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
-    add_index :related_words, [:origin_word_id, :related_word], unique: true
+    add_index :related_words, [ :origin_word_id, :related_word ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_07_081808) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_05_024949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,12 +39,19 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_07_081808) do
     t.index ["user_id"], name: "index_game_records_on_user_id"
   end
 
+  create_table "origin_words", force: :cascade do |t|
+    t.bigint "question_id", null: false
+    t.string "origin_word", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id"], name: "index_origin_words_on_question_id"
+  end
+
   create_table "question_tags", force: :cascade do |t|
     t.bigint "question_id", null: false
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["question_id", "tag_id"], name: "index_question_tags_on_question_id_and_tag_id", unique: true
     t.index ["question_id"], name: "index_question_tags_on_question_id"
     t.index ["tag_id"], name: "index_question_tags_on_tag_id"
   end
@@ -57,6 +64,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_07_081808) do
     t.datetime "updated_at", null: false
     t.index ["title"], name: "index_questions_on_title", unique: true
     t.index ["user_id"], name: "index_questions_on_user_id"
+  end
+
+  create_table "related_words", force: :cascade do |t|
+    t.bigint "origin_word_id", null: false
+    t.string "related_word", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["origin_word_id", "related_word"], name: "index_related_words_on_origin_word_id_and_related_word", unique: true
+    t.index ["origin_word_id"], name: "index_related_words_on_origin_word_id"
   end
 
   create_table "request_responses", force: :cascade do |t|
@@ -105,9 +121,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_07_081808) do
   add_foreign_key "card_sets", "questions"
   add_foreign_key "game_records", "questions"
   add_foreign_key "game_records", "users"
+  add_foreign_key "origin_words", "questions"
   add_foreign_key "question_tags", "questions"
   add_foreign_key "question_tags", "tags"
   add_foreign_key "questions", "users"
+  add_foreign_key "related_words", "origin_words"
   add_foreign_key "request_responses", "requests"
   add_foreign_key "request_responses", "users"
   add_foreign_key "requests", "questions"

--- a/spec/factories/origin_words.rb
+++ b/spec/factories/origin_words.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :origin_word do
+    question { nil }
+    origin_word { "MyString" }
+  end
+end

--- a/spec/factories/related_words.rb
+++ b/spec/factories/related_words.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :related_word do
+    origin_word { nil }
+    related_word { "MyString" }
+  end
+end

--- a/spec/models/origin_word_spec.rb
+++ b/spec/models/origin_word_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OriginWord, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/related_word_spec.rb
+++ b/spec/models/related_word_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RelatedWord, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 関連Issue
#118

## 概要
- card_setsテーブルを分割するためのorigin_wordsテーブル・related_wordsテーブルを作成しました。
- TablePlusを使用し、開発環境のcard_setsテーブルのデータをorigin_wards/related_wardsテーブルに反映しました。
（git差分には反映されません）