### PR TITLE
fix: postgresイメージをバージョン17に更新

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       TZ: Asia/Tokyo


### PR DESCRIPTION
## 概要
compose.ymlにて、 postgresイメージをバージョン17に設定しました。
（これまではバージョン指定なし。docker compose up時のエラーに伴い、設定）