### PR TITLE
add: 独自ドメインをホワイトリストに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,4 +115,6 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << "neuroword-nk.com"
+  config.hosts << "www.neuroword-nk.com"
 end


### PR DESCRIPTION
## Issue
close: #108

## 概要
- 本番環境で新ドメインからのアクセスを許可するための設定を追加
- 新たに「neuroword-nk.com」および「www.neuroword-nk.com」を許可ドメインとして登録（cloudflare使用）
- デプロイ後にアクセス制限エラーが発生しないよう対応

## 実装内容 
- `config/environments/production.rb` に以下の設定を追加  
```rb
  config.hosts << "neuroword-nk.com"
  config.hosts << "www.neuroword-nk.com"
```
## 確認項目
- [x]  https://neuroword-nk.com からアクセスできることを確認
- [x]  https://www.neuroword-nk.com からアクセスできることを確認
- [x] これまで同様、https://neuroword.onrender.com/からアクセスできることを確認 ※ #256 で修正