### PR TITLE
fix: render経由のURLもホワイトリストに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,5 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   config.hosts << "neuroword-nk.com"
   config.hosts << "www.neuroword-nk.com"
+  config.hosts << "https://neuroword.onrender.com/"
 end


### PR DESCRIPTION
## 概要
#254 で"https://neuroword.onrender.com/"からのアクセスが不可となったため、ホワイトリストに"https://neuroword.onrender.com/"も追加しました。