### PR TITLE
update: brakemanを7.1.0→7.1.1にアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.1.0)
+    brakeman (7.1.1)
       racc
     builder (3.3.0)
     bullet (8.0.8)


### PR DESCRIPTION
## 概要
- CIが通らなくなったのでbrakemanを7.1.0→7.1.1にアップデートしました。