### PR TITLE
update: いいねユーザーを、問題作成者のみ確認可能に変更

### DIFF
--- a/app/views/shared/_liked_count.html.erb
+++ b/app/views/shared/_liked_count.html.erb
@@ -9,7 +9,7 @@
 %>
 
 <%= turbo_frame_tag unique_id do %>
-<% if user_signed_in? %>
+<% if current_user && current_user.own?(question_obj) %>
     <div data-controller="favorite-modal">
       <button
         type="button"


### PR DESCRIPTION
## 概要

* 「いいね数」部分テンプレート（`_liked_count.html.erb`）の表示条件を見直し
* ログイン状態のみでなく、「投稿者本人かどうか」に基づいて表示を制御
* ログインユーザーが、他のユーザーに影響されずいいねしやすくしつつ、引き続き問題作成者のモチベーションに繋げることを考慮

## 実装内容

* `user_signed_in?` を `current_user && current_user.own?(question_obj)` に変更
* 投稿者本人のみにいいね数が表示されるようにロジックを修正

## 確認項目
* [x] 投稿者本人としてアクセスした場合に、いいね数が表示されること
* [x] 投稿者以外の場合に、いいね数が表示されないこと

