### PR TITLE
fix: バリデーションエラー時にローディングアニメーションが終了しない問題を修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,20 +6,21 @@ import * as echarts from 'echarts';
 window.echarts = echarts;
 
 // ローディングアニメーション
-document.addEventListener('turbo:load', function () {
+function hideLoading() {
   const spinner = document.getElementById("loading");
   if (spinner) {
     spinner.classList.add("loaded");
   }
-});
+}
 
 // 初回読み込み時
-document.addEventListener('DOMContentLoaded', function () {
-  const spinner = document.getElementById("loading");
-  if (spinner) {
-    spinner.classList.add("loaded");
-  }
-});
+document.addEventListener('DOMContentLoaded', hideLoading);
+
+// Turboページ遷移時
+document.addEventListener('turbo:load', hideLoading);
+
+// Turboレンダリング完了時（フォーム送信後のバリデーションエラー表示など）
+document.addEventListener('turbo:render', hideLoading);
 
 // Tagifyインスタンスをグローバルに保持
 let tagifyInstance = null


### PR DESCRIPTION
## 概要

* フォーム送信時のバリデーションエラー後、ローディングアニメーションが解除されず表示が残り続ける問題を修正
* `turbo:render` イベント発火時にもローディング非表示処理を追加

## 実装内容

* ローディング非表示処理を `hideLoading()` 関数として共通化
* `DOMContentLoaded` / `turbo:load` に加えて、`turbo:render` イベントでも `hideLoading()` を実行するよう修正

## 確認項目

* [x] バリデーションエラー発生時にローディングアニメーションが正常に非表示になること
* [x] Turbo遷移・初回ロード時にローディングアニメーションが問題なく消えること

