### PR TITLE
revert: omniauth-rails_csrf_protectionを1.0.2に戻す

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "tailwindcss-ruby"
 gem "devise"
 gem "omniauth"
 gem "omniauth-google-oauth2"
-gem "omniauth-rails_csrf_protection"
+gem "omniauth-rails_csrf_protection", "~> 1.0.2"
 
 gem "rack-attack"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       faraday-multipart (~> 1.0, >= 1.0.4)
       ostruct
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.4)
+    connection_pool (2.5.5)
     crass (1.0.6)
     date (3.5.0)
     debug (1.11.0)
@@ -262,7 +262,7 @@ GEM
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
       omniauth (~> 2.0)
-    omniauth-rails_csrf_protection (2.0.0)
+    omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
@@ -504,7 +504,7 @@ DEPENDENCIES
   meta-tags
   omniauth
   omniauth-google-oauth2
-  omniauth-rails_csrf_protection
+  omniauth-rails_csrf_protection (~> 1.0.2)
   pg (~> 1.1)
   puma (>= 5.0)
   rack-attack


### PR DESCRIPTION
## 概要
omniauth-rails_csrf_protectionを2.0.0から1.0.2に戻す
## バージョンダウン理由

1. #285 で2.0.0 にバージョンアップ後、テスト環境及び本番環境でGoogle認証が失敗するようになったため
2. [omniauth-rails_csrf_protectionのissue26](https://github.com/cookpad/omniauth-rails_csrf_protection/issues/26)でも、omniauth が失敗したという事象の申告を確認したため

## 備考
#285 のマージ前に本事象検知ができなかった理由
→ #285 のプルリクエスト時点では、RspecをCIに含めていなかったためと考えられる。