### PR TITLE
update: 問題カテゴリ表示欄にリンクを追加

### DIFF
--- a/app/views/shared/_category_and_tags.html.erb
+++ b/app/views/shared/_category_and_tags.html.erb
@@ -1,17 +1,16 @@
-<%
-  # ローカル変数
-%>
+<%= link_to questions_path(category_id: question.category_id), data: { turbo_frame: "_top" } do %>
+  <div class="flex items-center gap-2 px-2 rounded-sm hover:bg-base-300">
+    <i class="fa-solid fa-folder text-base-content/70"></i>
+    <%= question.category.name %>
+  </div>
+<% end %>
 
-<div class="flex items-center gap-2">
-  <i class="fa-solid fa-folder text-base-content/70"></i>
-  <%= question.category.name %>
-</div>
-<div class="flex flex-wrap items-center gap-1 justify-start max-w-xs">
+<div class="flex flex-wrap items-center gap-1 justify-start max-w-xs px-2">
   <% if question.tags.present? %>
     <div class="mb-3">
       <i class="fa-solid fa-tag mr-1 text-base-content/70"></i>
       <% question.tags.each do |tag| %>
-        <%= link_to truncate(tag.name, length: 10, omission: "…"), questions_path(category_id: params[:category_id], tag_name: tag.name, search_keyword: params[:search_keyword]), class: 'tag-badge badge badge-outline badge-info shadow-sm text-xs flex-shrink-0', title: tag.name %>
+        <%= link_to truncate(tag.name, length: 10, omission: "…"), questions_path(category_id: params[:category_id], tag_name: tag.name, search_keyword: params[:search_keyword]), class: 'tag-badge badge badge-outline badge-info shadow-sm text-xs flex-shrink-0', title: tag.name, data: { turbo_frame: "_top" } %>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION

## 概要

* カテゴリ名をクリック可能なリンクに変更し、カテゴリでの絞り込みページへ遷移できるようにした
* タグリンクに `data: { turbo_frame: "_top" }` を追加し、Turbo Frame の影響を受けずにページ全体で遷移できるよう改善
* UI の調整（カテゴリ部分の hover スタイル・padding 追加など）

## 実装内容

* カテゴリ表示部分を `link_to` で囲み、`questions_path(category_id: question.category_id)` へ遷移するリンク化
* カテゴリ部分に `hover:bg-base-300` や `px-2` を追加してデザインを調整
* タグリンクに `data: { turbo_frame: "_top" }` を追加
* タグコンテナに `px-2` を追加し、全体的なレイアウトを整えた

## 確認項目

* [x] カテゴリ名クリックで質問一覧ページ（カテゴリ絞り込み）へ正常に遷移する
* [x] タグクリック時に Turbo Frame ではなくページ全体で遷移する
* [x] 既存のタグ・カテゴリ表示が崩れていないこと
