### PR TITLE
fix: まとめてプレイモードが実行できない問題を解消

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -23,7 +23,7 @@ class GamesController < ApplicationController
 
     # 遷移元をチェック
     referer = request.referer || ""
-    from_mypage_lists = referer.include?("user/mypage") && referer.include?("tab=user_lists")
+    from_mypage_lists = referer.include?("/mypage") && referer.include?("tab=user_lists")
     from_batch_game = referer.include?("/games/") && session[:batch_play_mode]
 
     # バッチプレイモード中だが、以下の条件を満たす場合はセッションをクリア


### PR DESCRIPTION
## 概要

* app/controllers/games_controller.rbにおける遷移元（`request.referer`） の判定条件を修正し、マイページ経由の遷移を正しく検知できるように対応
* 不正な判定によるまとめてプレイモードの誤解除を防止

## 実装内容

* `from_mypage_lists` の参照パス判定を `"user/mypage"` → `"/mypage"` に修正
  （実際のルーティング構造に合わせて条件を適正化）

## 確認項目

* [x] マイページ（ユーザリストタブ）から遷移した際にまとめてプレイモードが実行できること
* [x] 上記以外の遷移パターンでは従来どおりの挙動を維持していること
