### PR TITLE
delete: gem "cloudinary"を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ gem "devise-i18n"
 
 gem "rails-i18n"
 
-gem "cloudinary"
 gem "meta-tags"
 
 gem "kaminari"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,11 +104,6 @@ GEM
     cgi (0.5.1)
     childprocess (5.1.0)
       logger (~> 1.5)
-    cloudinary (2.3.1)
-      faraday (>= 2.0.1, < 3.0.0)
-      faraday-follow_redirects (~> 0.3.0)
-      faraday-multipart (~> 1.0, >= 1.0.4)
-      ostruct
     concurrent-ruby (1.3.5)
     connection_pool (3.0.2)
     crass (1.0.6)
@@ -142,10 +137,6 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.3.0)
-      faraday (>= 1, < 3)
-    faraday-multipart (1.1.1)
-      multipart-post (~> 2.0)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
     globalid (1.2.1)
@@ -212,7 +203,6 @@ GEM
     msgpack (1.8.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
-    multipart-post (2.4.1)
     net-http (0.6.0)
       uri
     net-imap (0.5.9)
@@ -266,7 +256,6 @@ GEM
       actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
-    ostruct (0.6.2)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -495,7 +484,6 @@ DEPENDENCIES
   brakeman
   bullet
   capybara
-  cloudinary
   debug
   devise
   devise-i18n


### PR DESCRIPTION
## 概要
- gem "cloudinary" を削除しました。
## 備考
- 本アプリ内でのCloudinary使用においては、画像URLを文字列として参照しているだけなのでgemは不要。