### PR TITLE
update: dockerfileで、Node.jsを 20.19.2 から 20.20.0 に更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies
-ARG NODE_VERSION=20.19.2
+ARG NODE_VERSION=20.20.0
 ARG YARN_VERSION=1.22.22
 ENV PATH=/usr/local/node/bin:$PATH
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \


### PR DESCRIPTION
## 概要
[Node.jsのセキュリティリリース](https://forest.watch.impress.co.jp/docs/news/2077577.html)に伴い、Nodo.jsを20.19.2 から 20.20.0 に更新しました。

## 備考
こちらのプルリクエストではDockerfile のみ更新いたしましたが、マージ後も本番環境に更新が反映されなかったため #331 
で.node-versionファイルの更新も実施しております。

## 確認方法
Dockerfile、.node-versionファイルを更新のうえ以下を実施。

### ローカル環境
1. キャッシュなしで再ビルド
`docker compose build --no-cache`

2. バージョン確認
```
docker compose run --rm web node --version
# 期待値：v20.20.0
```

3. アプリケーション起動確認
`docker compose up`

### Render（本番環境）
※ Renderのシェルで実行
```
node --version
# 期待値：v20.20.0
```