### PR TITLE
update:  Deviseのセッションタイムアウト時間を延長

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -188,7 +188,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 30.minutes
+  config.timeout_in = 2.weeks
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
## 概要
- Deviseのセッションタイムアウト時間を延長
- 一定時間操作がない場合の自動ログアウト頻度を緩和
- 利用中に意図せずログアウトされる体験を改善

## 実装内容 
- `config/initializers/devise.rb` の `config.timeout_in` を `30.minutes` から `2.weeks` に変更
- セッション有効期間を2週間に設定

## 確認項目 
- [ ] ログイン後、30分以上操作しなくてもログアウトされないこと
- [ ] セッションが2週間経過後にログインが必要となること
