### PR TITLE
update: READMEにResend（メール送信技術）の記載を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@
 | フロントエンド | TailwindCSS / daisyUI / Hotwire (Turbo, Stimulus)          |
 | データベース   | PostgreSQL                       |
 | デプロイ       | Render                           |
+| メール送信       | Resend                           |
 | 認証           | Devise / OmniAuth (Google OAuth2)|
 
 ### 主要な使用技術と用途
@@ -250,6 +251,7 @@
 * Cloudinary - 動的OGP画像生成
 * meta-tags - OGP・SEO対応
 * Cloudflare - 独自ドメイン
+* Resend - パスワードリセットにおけるメール送信
 
 ## ![icon Image](public/icon.ico) ER図
 


### PR DESCRIPTION
## 概要
- 使用技術一覧に「メール送信：Resend」を追記
- 主要な使用技術と用途に Resend の利用目的（パスワードリセットメール送信）を追記

## 実装内容 
- README.md の「使用技術」テーブルに Resend を追加
- README.md の「主要な使用技術と用途」に Resend の説明を追加（パスワードリセット用）
