### PR TITLE
refactor:カードマッチングロジックをコマンドオブジェクト化 

### DIFF
--- a/app/commands/match_card_command.rb
+++ b/app/commands/match_card_command.rb
@@ -1,0 +1,54 @@
+# 起点カード選択済み（SELECT_RELATED状態）かつ正しいセットへの回答かを検証する。
+class MatchCardCommand
+  Result = Struct.new(:valid_action, :correct, :message, :game_completed, keyword_init: true)
+
+  def initialize(question:, game_state:, params:)
+    @question           = question
+    @game_state         = game_state
+    @selected_origin_id = params[:origin_set_id]&.to_i
+    @related_word       = params[:related_word]
+    @clicked_set_id     = params[:clicked_set_id].to_i
+    @current_state      = params[:current_state]
+  end
+
+  def call
+    return invalid_state_result unless valid_state?
+
+    if correct_match?
+      @game_state.add_correct_match(@selected_origin_id, @related_word)
+      @game_state.increment_correct_clicks
+      Result.new(valid_action: true, correct: true, message: "正解！", game_completed: @game_state.game_completed?)
+    else
+      Result.new(valid_action: true, correct: false, message: error_message, game_completed: false)
+    end
+  end
+
+  private
+
+  def valid_state?
+    # SELECT_RELATED: 起点カード選択後、関連語カードの選択を待つ状態
+    @selected_origin_id.present? && @current_state == "SELECT_RELATED"
+  end
+
+  def correct_match?
+    # clicked_set_idが一致しない場合、関連語が正しくても別セットへの誤操作となるため両条件が必要
+    origin_word.related_words.pluck(:related_word).include?(@related_word) &&
+      @clicked_set_id == @selected_origin_id
+  end
+
+  def origin_word
+    @origin_word ||= @question.origin_words.find(@selected_origin_id)
+  end
+
+  def error_message
+    if @clicked_set_id != @selected_origin_id
+      "選択したカードは、現在の起点カードとセットになっていません"
+    else
+      "不正解..."
+    end
+  end
+
+  def invalid_state_result
+    Result.new(valid_action: false, correct: false, message: "まず起点カードを選択してください", game_completed: false)
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -100,63 +100,28 @@ class GamesController < ApplicationController
   end
 
   def handle_related_click
-    selected_origin_id = params[:origin_set_id]&.to_i
-    related_word = params[:related_word]
-    clicked_set_id = params[:clicked_set_id].to_i
-    current_state = params[:current_state]
+    result = MatchCardCommand.new(
+      question:   @question,
+      game_state: game_state,
+      params:     params
+    ).call
 
-    # 起点カードが選択されていない場合
-    if selected_origin_id.nil? || current_state != "SELECT_RELATED"
-      render json: {
-        valid_action: false,
-        correct: false,
-        message: "まず起点カードを選択してください",
-        total_clicks: session[:total_clicks],
-        correct_clicks: session[:correct_clicks],
-        current_accuracy: calculate_current_accuracy
-      }
-      return
+    response = {
+      valid_action:     result.valid_action,
+      correct:          result.correct,
+      message:          result.message,
+      total_clicks:     session[:total_clicks],
+      correct_clicks:   session[:correct_clicks],
+      current_accuracy: calculate_current_accuracy
+    }
+
+    if result.correct
+      response[:total_matches]    = session[:correct_matches].length
+      response[:required_matches] = session[:total_required_matches]
+      response[:game_completed]   = result.game_completed
     end
 
-    # マッチング判定
-    origin_word = @question.origin_words.find(selected_origin_id)
-    is_correct = origin_word.related_words.pluck(:related_word).include?(related_word)
-    is_valid_match = (clicked_set_id == selected_origin_id)
-
-    if is_correct && is_valid_match
-      # 正解の場合
-      game_state.add_correct_match(selected_origin_id, related_word)
-      game_state.increment_correct_clicks
-      game_completed = game_state.game_completed?
-
-      render json: {
-        valid_action: true,
-        correct: true,
-        total_matches: session[:correct_matches].length,
-        required_matches: session[:total_required_matches],
-        game_completed: game_completed,
-        total_clicks: session[:total_clicks],
-        correct_clicks: session[:correct_clicks],
-        current_accuracy: calculate_current_accuracy,
-        message: "正解！"
-      }
-    else
-      # 不正解の場合
-      message = if !is_valid_match
-                  "選択したカードは、現在の起点カードとセットになっていません"
-      else
-                  "不正解..."
-      end
-
-      render json: {
-        valid_action: true,
-        correct: false,
-        message: message,
-        total_clicks: session[:total_clicks],
-        correct_clicks: session[:correct_clicks],
-        current_accuracy: calculate_current_accuracy
-      }
-    end
+    render json: response
   end
 
   def session_delete

--- a/spec/commands/match_card_command_spec.rb
+++ b/spec/commands/match_card_command_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe MatchCardCommand do
   let(:question) { create(:question) }
-  let(:origin_word) { create(:origin_word, question: question, related_words_list: ['正解ワード']) }
+  let(:origin_word) { create(:origin_word, question: question, related_words_list: [ '正解ワード' ]) }
   let(:game_state) { instance_double(GameStateManager) }
   let(:command) { described_class.new(question: question, game_state: game_state, params: params) }
 

--- a/spec/commands/match_card_command_spec.rb
+++ b/spec/commands/match_card_command_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe MatchCardCommand do
+  let(:question) { create(:question) }
+  let(:origin_word) { create(:origin_word, question: question, related_words_list: ['正解ワード']) }
+  let(:game_state) { instance_double(GameStateManager) }
+  let(:command) { described_class.new(question: question, game_state: game_state, params: params) }
+
+  describe '#call' do
+    context 'SELECT_RELATED状態でない場合' do
+      let(:params) { { origin_set_id: nil, related_word: '正解ワード', clicked_set_id: '1', current_state: 'SELECT_ORIGIN' } }
+
+      it 'valid_action: falseを返す' do
+        result = command.call
+        expect(result.valid_action).to be false
+        expect(result.message).to eq('まず起点カードを選択してください')
+      end
+    end
+
+    context 'SELECT_RELATED状態の場合' do
+      context '正しいマッチの場合' do
+        let(:params) do
+          { origin_set_id: origin_word.id.to_s, related_word: '正解ワード',
+            clicked_set_id: origin_word.id.to_s, current_state: 'SELECT_RELATED' }
+        end
+
+        before do
+          allow(game_state).to receive(:add_correct_match)
+          allow(game_state).to receive(:increment_correct_clicks)
+          allow(game_state).to receive(:game_completed?).and_return(false)
+        end
+
+        it 'valid_action: true、correct: trueを返す' do
+          result = command.call
+          expect(result.valid_action).to be true
+          expect(result.correct).to be true
+          expect(result.message).to eq('正解！')
+        end
+
+        it 'game_stateに正解を記録する' do
+          expect(game_state).to receive(:add_correct_match).with(origin_word.id, '正解ワード')
+          expect(game_state).to receive(:increment_correct_clicks)
+          command.call
+        end
+      end
+
+      context 'セットIDが一致しない場合' do
+        let(:other_origin_word) { create(:origin_word, question: question, origin_word: '別の起点語') }
+        let(:params) do
+          { origin_set_id: origin_word.id.to_s, related_word: '正解ワード',
+            clicked_set_id: other_origin_word.id.to_s, current_state: 'SELECT_RELATED' }
+        end
+
+        it 'valid_action: true、correct: falseを返す' do
+          result = command.call
+          expect(result.valid_action).to be true
+          expect(result.correct).to be false
+          expect(result.message).to eq('選択したカードは、現在の起点カードとセットになっていません')
+        end
+      end
+
+      context 'related_wordが不一致の場合' do
+        let(:params) do
+          { origin_set_id: origin_word.id.to_s, related_word: '不正解ワード',
+            clicked_set_id: origin_word.id.to_s, current_state: 'SELECT_RELATED' }
+        end
+
+        it 'valid_action: true、correct: falseを返す' do
+          result = command.call
+          expect(result.valid_action).to be true
+          expect(result.correct).to be false
+          expect(result.message).to eq('不正解...')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Issue
close: #359 

## 概要
- relatedカード選択時のマッチ判定処理を `MatchCardCommand` として切り出しました
- `GamesController#handle_related_click` の分岐と判定ロジックを整理し、レスポンス組み立てに責務を寄せました
- `MatchCardCommand` の挙動を確認するRSpecを追加しました

## 実装内容 
- `app/commands/match_card_command.rb` を新規作成し、`SELECT_RELATED` 状態の検証、正誤判定、エラーメッセージ返却、ゲーム完了判定をまとめました
- `GamesController#handle_related_click` から判定ロジックを削除し、Commandの実行結果をもとにJSONレスポンスを返す形に変更しました
- Command specを追加し、起点カード未選択時・正解時・セット不一致時・不正解時の返却値と `game_state` への反映を確認できるようにしました

## 確認項目 
- [x] 起点カード未選択時に「まず起点カードを選択してください」が返ること
- [x] 正しい組み合わせ選択時に正解判定・進捗更新・ゲーム完了判定が返ること
- [x] セットID不一致時に専用メッセージが返ること