### PR TITLE
fix: Google認証失敗メッセージの色を修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -35,10 +35,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   #   super
   # end
 
-  # GET|POST /users/auth/twitter/callback
+  # GET|POST /users/auth/google/callback
   def failure
     redirect_to root_path
-    set_flash_message(:notice, :failure, kind: "Google") if is_navigational_format?
+    set_flash_message(:alert, :failure, kind: "Google") if is_navigational_format?
   end
 
   # protected


### PR DESCRIPTION
## 概要
- Google認証失敗時のフラッシュ種別を `notice`(青色) から `alert`(赤色) に変更しました
- Google認証失敗時のメッセージが、失敗として分かりやすく表示されるようにしました
- OmniAuth コールバック周りのコメント表記を Google 用に修正しました

## 実装内容 
- `Users::OmniauthCallbacksController#failure` 内の `set_flash_message` を `:notice` から `:alert` に変更
- `GET|POST /users/auth/twitter/callback` となっていたコメントを `GET|POST /users/auth/google/callback` に修正

## 確認項目 
- [x] Google認証失敗時にフラッシュメッセージが  赤色で表示されること