### PR TITLE
add: ユーザー削除機能を追加

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,7 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [ :create ]
   before_action :configure_account_update_params, only: [ :update ]
+  before_action :authenticate_user!, only: [ :destroy ]
 
   # GET /resource/sign_up
   # def new
@@ -53,7 +54,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # DELETE /resource
   # def destroy
-  #   super
+  #   #   super
   # end
 
   # GET /resource/cancel

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -1,9 +1,45 @@
 <div class="flex items-center mb-2">
   <h1 class="text-2xl font-bold"><%= @user.name %></h1>
   <% if @user == current_user %>
-    <%= link_to edit_user_registration_path(redirect_to: redirect_path), class: "btn btn-outline btn-success btn-sm ml-3" do %>
-      <i class="fa-solid fa-pen"></i>
-    <% end %>
+    <div class="dropdown dropdown-center">
+        <div tabindex="0" role="button" class="btn btn-ghost"><i class="fa-solid fa-ellipsis-vertical"></i></div>
+        <ul tabindex="-1" class="dropdown-content menu bg-gradient-to-br from-base-100 to-base-200 rounded-box z-1 w-52 px-2 shadow-sm">
+          <li>
+            <%= link_to edit_user_registration_path(redirect_to: redirect_path) do %>
+              <i class="fa-solid fa-pen text-success/70" aria-hidden="true"></i>
+              ユーザー編集
+            <% end %>
+          </li>
+          <li>
+            <!-- Open the modal using ID.showModal() method -->
+            <button class="text-warning" onclick="my_modal_5.showModal()">
+              <i class="fa-solid fa-trash text-warning/70" aria-hidden="true"></i>
+              アカウントを削除する
+            </button>
+            <dialog id="my_modal_5" class="modal modal-bottom sm:modal-middle">
+              <div class="modal-box min-w-72">
+                <h3 class="text-lg font-bold">このアカウントを削除しますか？</h3>
+                <p class="py-4">この操作は取り消せません。</p>
+                <p class="py-4">登録した問題・学習履歴など、すべてのデータが削除されます。</p>
+                <div class="modal-action">
+                  <form method="dialog">
+                    <button class="btn">キャンセル</button>
+                  </form>
+                  <%= button_to user_registration_path,
+                    method: :delete,
+                    class: "btn btn-error",
+                    data: { turbo_confirm: t('defaults.delete_confirm') } do %>
+                    <i class="fa-solid fa-trash" aria-hidden="true"></i>
+                    アカウントを削除する
+                  <% end %>
+                </div>
+              </div>
+            </dialog>
+          </li>
+        </ul>
+      </div>
+
+
   <% end %>
 </div>
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -93,8 +93,50 @@ RSpec.describe "Users", type: :system do
         # fill_in 'ユーザー名', with: 'newname'
       end
 
-      xit 'アカウントを削除できる' do
-        # ログイン → アカウント削除 → 確認画面 → 削除実行 → トップページ遷移
+      it 'アカウントを削除できる' do
+        login(user)
+        visit mypage_path
+        find('.btn-error').click
+        expect(current_path).to eq root_path
+        expect(page).to have_content('アカウントを削除しました。またのご利用をお待ちしております。')
+        expect(User.exists?(user.id)).to be false
+      end
+
+      context '削除後の状態' do
+        let!(:question) { create(:question, user: user) }
+        let!(:game_record) { create(:game_record, user: user, question: question) }
+
+        before do
+          login(user)
+          visit mypage_path
+          find('.btn-error').click
+        end
+
+        it '確認後にアカウントが削除され、関連データが削除される' do
+          expect(User.exists?(user.id)).to be false
+          expect(Question.exists?(question.id)).to be false
+          expect(GameRecord.exists?(game_record.id)).to be false
+        end
+
+        it '削除後、トップページへリダイレクトされセッションがクリアされる' do
+          expect(current_path).to eq root_path
+          visit mypage_path
+          expect(current_path).to eq new_user_session_path
+        end
+      end
+
+      context '本人以外による削除' do
+        it '他ユーザーのプロフィールページには削除ボタンが表示されない' do
+          other_user = create(:user)
+          login(other_user)
+          visit user_path(user)
+          expect(page).not_to have_selector('.btn-error')
+        end
+
+        it '未ログイン状態では削除できず、ログインページへリダイレクトされる' do
+          page.driver.delete user_registration_path
+          expect(page.driver.response.location).to include(new_user_session_path)
+        end
       end
     end
   end


### PR DESCRIPTION
## Issue
close: #402

## 概要
- マイページのユーザー操作メニューからアカウント削除を実行できるようにしました。
- アカウント削除前に、取り消し不可であることを確認するモーダルを表示するようにしました。
- アカウント削除時の関連データ削除、リダイレクト、未ログイン時の制御を確認するテストを追加しました。

## 実装内容
- プロフィール表示部分にドロップダウンメニューを追加
- ユーザー編集リンクをドロップダウン内に移動
- アカウント削除用の確認モーダルと削除ボタンを追加
- アカウント削除処理にログイン必須の制御を追加
- アカウント削除に関するsystem specを追加

## 確認項目
- [x] 自分のマイページからアカウントを削除できること
- [x] アカウント削除後、トップページへ遷移すること
- [x] アカウント削除後、ユーザー情報・登録した問題・学習履歴が削除されること
- [x] 削除後にマイページへアクセスするとログインページへ遷移すること
- [x] 他ユーザーのプロフィールページには削除ボタンが表示されないこと
- [x] 未ログイン状態で削除リクエストを送るとログインページへリダイレクトされること